### PR TITLE
Add UserIdSet to the Workout class to see which users are linked to a given workout.

### DIFF
--- a/app/src/main/java/com/android/sample/model/workout/BodyWeightWorkout.kt
+++ b/app/src/main/java/com/android/sample/model/workout/BodyWeightWorkout.kt
@@ -1,25 +1,62 @@
 package com.android.sample.model.workout
 
-// BodyWeight workout description
+/**
+ * Represents a bodyweight workout session which includes a list of bodyweight exercises.
+ *
+ * @param workoutId Unique identifier for the workout.
+ * @param name Name of the workout.
+ * @param description Brief description of the workout.
+ * @param warmup Boolean indicating if the workout includes a warmup.
+ * @param userIdSet Set of user IDs associated with this workout (defaults to an empty set).
+ * @param exercises List of exercises included in the workout (defaults to an empty list).
+ */
 class BodyWeightWorkout(
     workoutId: String,
     name: String,
     description: String,
     warmup: Boolean,
+    userIdSet: MutableSet<String> = mutableSetOf(),
     val exercises: MutableList<BodyWeightExercise> = mutableListOf() // Default to an empty list
-) : Workout(workoutId, name, description, warmup) {
+) : Workout(workoutId, name, description, warmup, userIdSet) {
 
-  // Function to add an exercise
+  /**
+   * Adds a [BodyWeightExercise] to the list of exercises in the workout.
+   *
+   * @param exercise The [BodyWeightExercise] to be added.
+   */
   fun addExercise(exercise: BodyWeightExercise) {
     exercises.add(exercise)
   }
 
-  // Function to remove an exercise of the workout using the exercise Id
+  /**
+   * Removes a [BodyWeightExercise] from the workout by its [exerciseId].
+   *
+   * @param exerciseId The unique ID of the exercise to remove.
+   */
   fun removeExerciseById(exerciseId: String) {
     exercises.removeAll { it.exerciseId == exerciseId }
   }
+
+  /**
+   * Adds a user to the workout by their ID.
+   *
+   * @param id The ID of the user to be added to the workout.
+   */
+  fun addUserById(id: String) {
+    userIdSet.add(id)
+  }
+
+  /**
+   * Removes a user from the workout by their ID.
+   *
+   * @param id The ID of the user to be removed from the workout.
+   */
+  fun removeUserById(id: String) {
+    userIdSet.removeAll { it == id }
+  }
 }
 
+/** Enum class representing various types of bodyweight exercises. */
 enum class BodyWeightExerciseType {
   PUSH_UPS,
   SQUATS,
@@ -27,6 +64,13 @@ enum class BodyWeightExerciseType {
   CHAIR
 }
 
+/**
+ * Data class representing a specific bodyweight exercise.
+ *
+ * @param exerciseId Unique identifier for the exercise.
+ * @param type Type of the bodyweight exercise, represented by [BodyWeightExerciseType].
+ * @param detail Additional details about the exercise, stored in [ExerciseDetail].
+ */
 data class BodyWeightExercise(
     val exerciseId: String,
     val type: BodyWeightExerciseType,

--- a/app/src/main/java/com/android/sample/model/workout/Workout.kt
+++ b/app/src/main/java/com/android/sample/model/workout/Workout.kt
@@ -4,7 +4,9 @@ open class Workout(
     val workoutId: String, // Uniquely identifies the workout among all others
     val name: String,
     val description: String,
-    val warmup: Boolean // Whether the user want to do a warmup
+    val warmup: Boolean, // Whether the user want to do a warmup
+    val userIdSet:
+        MutableSet<String> // Set of userId that represent the User linked to a specific workout
 )
 
 // Detail of the exercise based on its type

--- a/app/src/main/java/com/android/sample/model/workout/YogaWorkout.kt
+++ b/app/src/main/java/com/android/sample/model/workout/YogaWorkout.kt
@@ -1,25 +1,62 @@
 package com.android.sample.model.workout
 
-// Yoga workout description
+/**
+ * Represents a Yoga workout session which includes a list of yoga exercises.
+ *
+ * @param workoutId Unique identifier for the workout.
+ * @param name Name of the workout.
+ * @param description Brief description of the workout.
+ * @param warmup Boolean indicating if the workout includes a warmup.
+ * @param userIdSet Set of user IDs associated with this workout (defaults to an empty set).
+ * @param exercises List of exercises included in the workout (defaults to an empty list).
+ */
 class YogaWorkout(
     workoutId: String,
     name: String,
     description: String,
     warmup: Boolean,
+    userIdSet: MutableSet<String> = mutableSetOf(),
     val exercises: MutableList<YogaExercise> = mutableListOf() // Default to an empty list
-) : Workout(workoutId, name, description, warmup) {
+) : Workout(workoutId, name, description, warmup, userIdSet) {
 
-  // Function to add an exercise
+  /**
+   * Adds a [YogaExercise] to the list of exercises in the workout.
+   *
+   * @param exercise The [YogaExercise] to be added.
+   */
   fun addExercise(exercise: YogaExercise) {
     exercises.add(exercise) // Correctly adds the exercise to the list
   }
 
-  // Function to remove an exercise of the workout using the exercise Id
+  /**
+   * Removes a [YogaExercise] from the workout by its [exerciseId].
+   *
+   * @param exerciseId The unique ID of the exercise to remove.
+   */
   fun removeExerciseById(exerciseId: String) {
     exercises.removeAll { it.exerciseId == exerciseId }
   }
+
+  /**
+   * Adds a user to the workout by their ID.
+   *
+   * @param id The ID of the user to be added to the workout.
+   */
+  fun addUserById(id: String) {
+    userIdSet.add(id)
+  }
+
+  /**
+   * Removes a user from the workout by their ID.
+   *
+   * @param id The ID of the user to be removed from the workout.
+   */
+  fun removeUserById(id: String) {
+    userIdSet.removeAll { it == id }
+  }
 }
 
+/** Enum class representing various types of yoga exercises. */
 enum class YogaExerciseType {
   DOWNWARD_DOG,
   TREE_POSE,
@@ -27,6 +64,13 @@ enum class YogaExerciseType {
   WARRIOR_II
 }
 
+/**
+ * Data class representing a specific yoga exercise.
+ *
+ * @param exerciseId Unique identifier for the exercise.
+ * @param type Type of the yoga exercise, represented by [YogaExerciseType].
+ * @param detail Additional details about the exercise, stored in [ExerciseDetail].
+ */
 data class YogaExercise(
     val exerciseId: String,
     val type: YogaExerciseType,

--- a/app/src/test/java/com/android/sample/model/workout/BodyWeightWorkoutTest.kt
+++ b/app/src/test/java/com/android/sample/model/workout/BodyWeightWorkoutTest.kt
@@ -6,6 +6,8 @@ import org.junit.Test
 class BodyWeightWorkoutTest {
   val WORKOUT_ID = "001"
   val EX_ID = "ExoId"
+  val USER_ID_1 = "UID1"
+  val USER_ID_2 = "UID2"
 
   @Test
   fun testBodyWeightWorkoutCreation() {
@@ -14,12 +16,14 @@ class BodyWeightWorkoutTest {
             workoutId = WORKOUT_ID,
             name = "Bodyweight Strength",
             description = "A workout focused on bodyweight exercises.",
-            warmup = true)
+            warmup = true,
+            userIdSet = mutableSetOf(USER_ID_1))
     assertEquals(WORKOUT_ID, workout.workoutId)
     assertEquals("Bodyweight Strength", workout.name)
     assertEquals("A workout focused on bodyweight exercises.", workout.description)
     assertEquals(true, workout.warmup)
     assertEquals(0, workout.exercises.size) // Initially, exercises should be empty
+    assertEquals(mutableSetOf(USER_ID_1), workout.userIdSet)
   }
 
   @Test
@@ -63,5 +67,38 @@ class BodyWeightWorkoutTest {
     workout.removeExerciseById("001") // Removing pushUps1 by its Id
     assertEquals(1, workout.exercises.size) // Now should have 2 exercises
     assertEquals(pushUps2, workout.exercises[0]) // Check if the exercise is correctly removed
+  }
+
+  @Test
+  fun testAddUserIdIntoBodyWeightWorkout() {
+    val workout =
+        BodyWeightWorkout(
+            workoutId = WORKOUT_ID,
+            name = "Bodyweight Strength",
+            description = "A workout focused on bodyweight exercises.",
+            warmup = true) // UserId Set is initially empty
+
+    workout.addUserById(USER_ID_1)
+    assertEquals(1, workout.userIdSet.size)
+    workout.addUserById(USER_ID_2)
+    assertEquals(2, workout.userIdSet.size)
+    assertEquals(mutableSetOf(USER_ID_1, USER_ID_2), workout.userIdSet)
+  }
+
+  @Test
+  fun testRemoveUserIdFromBodyWeightWorkout() {
+    val workout =
+        BodyWeightWorkout(
+            workoutId = WORKOUT_ID,
+            name = "Bodyweight Strength",
+            description = "A workout focused on bodyweight exercises.",
+            warmup = true,
+            userIdSet = mutableSetOf(USER_ID_1, USER_ID_2)) // UserId Set is initially empty
+
+    workout.removeUserById(USER_ID_1)
+    assertEquals(1, workout.userIdSet.size)
+    workout.removeUserById(USER_ID_2)
+    assertEquals(0, workout.userIdSet.size)
+    assertEquals(mutableSetOf<String>(), workout.userIdSet)
   }
 }

--- a/app/src/test/java/com/android/sample/model/workout/YogaWorkoutTest.kt
+++ b/app/src/test/java/com/android/sample/model/workout/YogaWorkoutTest.kt
@@ -6,6 +6,8 @@ import org.junit.Test
 class YogaWorkoutTest {
   val WORKOUT_ID = "001"
   val EX_ID = "ExoId"
+  val USER_ID_1 = "UID1"
+  val USER_ID_2 = "UID2"
 
   @Test
   fun testYogaWorkoutCreation() {
@@ -14,12 +16,14 @@ class YogaWorkoutTest {
             workoutId = WORKOUT_ID,
             name = "Morning Yoga Flow",
             description = "A calming yoga routine to start your day.",
-            warmup = false)
+            warmup = false,
+            userIdSet = mutableSetOf(USER_ID_1, USER_ID_2))
     assertEquals(WORKOUT_ID, workout.workoutId)
     assertEquals("Morning Yoga Flow", workout.name)
     assertEquals("A calming yoga routine to start your day.", workout.description)
     assertEquals(false, workout.warmup)
     assertEquals(0, workout.exercises.size) // Initially, exercises should be empty
+    assertEquals(mutableSetOf(USER_ID_2, USER_ID_1), workout.userIdSet)
   }
 
   @Test
@@ -60,5 +64,37 @@ class YogaWorkoutTest {
     workout.removeExerciseById("001") // remove downwardDog1 from the workout
     assertEquals(1, workout.exercises.size) // Now should have 1 exercise
     assertEquals(downwardDog2, workout.exercises[0]) // Check if the exercise is correctly removed
+  }
+
+  @Test
+  fun testAddUserIdIntoYogaWorkout() {
+    val workout =
+        YogaWorkout(
+            workoutId = WORKOUT_ID,
+            name = "Morning Yoga Flow",
+            description = "A calming yoga routine to start your day.",
+            warmup = false)
+    workout.addUserById(USER_ID_1)
+    assertEquals(1, workout.userIdSet.size)
+    workout.addUserById(USER_ID_2)
+    assertEquals(2, workout.userIdSet.size)
+    assertEquals(mutableSetOf(USER_ID_1, USER_ID_2), workout.userIdSet)
+  }
+
+  @Test
+  fun testRemoveUserIdFromYogaWorkout() {
+    val workout =
+        YogaWorkout(
+            workoutId = WORKOUT_ID,
+            name = "Morning Yoga Flow",
+            description = "A calming yoga routine to start your day.",
+            userIdSet = mutableSetOf(USER_ID_1, USER_ID_2),
+            warmup = false)
+
+    workout.removeUserById(USER_ID_1)
+    assertEquals(1, workout.userIdSet.size)
+    workout.removeUserById(USER_ID_2)
+    assertEquals(0, workout.userIdSet.size)
+    assertEquals(mutableSetOf<String>(), workout.userIdSet)
   }
 }


### PR DESCRIPTION
# Added features: 

- Workout.kt -> Add the userIdSet field in Workout class.

- BodyWeightWorkout.kt -> Add add&removeUserById function.

- YogaWorkout.kt -> Add add&removeUserById function.

# Added documentations (Produced by ChatGPT):
- BodyWeightWorkout.kt
- YogaWorkout.kt

# Added tests: 
BodyWeightWorkoutTest.kt ->testRemoveUserIdFromBodyWeightWorkout() &   testAddUserIdIntoBodyWeightWorkout()
YogaWorkoutTest.kt -> testRemoveUserIdFromYogaWorkout() &   testAddUserIdIntoYogaWorkout()

# Updated tests:
-testUserAccountCreation
- testBodyWeightWorkoutCreation
- testAddExercise
- testAddYogaExercise
- testYogaWorkoutCreation
>These tests have been updated to fit the new architecture of their respective class
 # Summary: 

This PR updates the acrhitecture of the Workout and thus the architecture of BodyWeightWorkout and YokgaWokout class. These changes allow a workout to be shared with other users by adding their Id into the userIdSet

# Warning:
These feature have to me manipulated with precaution to guarantee coherence and integrity among user. This means that If a workout is shared among multiple users, the workout has to be refresehd from Firesotre before any change. 