### PR TITLE
Add tests for the Navigation and the Preference features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - fix/Complete-Tests
 
   pull_request:
     types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - fix/Complete-Tests
 
   pull_request:
     types:

--- a/app/src/androidTest/java/com/android/sample/screen/PreferencesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/PreferencesScreenTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 class PreferencesScreenTest {
@@ -80,6 +81,9 @@ class PreferencesScreenTest {
   fun savingPreferencesCallsUpdatePreferences() {
     composeTestRule.setContent { PreferencesScreen(mockNavHostController, preferencesViewModel) }
     val secondPreferences = Preferences(unitsSystem = UnitsSystem.IMPERIAL, weight = WeightUnit.LBS)
+    // check that users has default value of preferences
+    composeTestRule.onNodeWithTag("unitsSystemButton").assertTextEquals("METRIC")
+    composeTestRule.onNodeWithTag("weightUnitButton").assertTextEquals("KG")
 
     // Simulate user changing the system of units and weight unit
     // from (METRIC, KG) to (IMPERIAL, LBS)
@@ -91,6 +95,10 @@ class PreferencesScreenTest {
     // Save the changes
     composeTestRule.onNodeWithTag("preferencesSaveButton").performClick()
 
+    // check that users has default (IMPERIAL, LBS) of preferences
+    composeTestRule.onNodeWithTag("unitsSystemButton").assertTextEquals("IMPERIAL")
+    composeTestRule.onNodeWithTag("weightUnitButton").assertTextEquals("LBS")
+
     // check if the preferences were updated in the repository
     verify(mockPreferencesRepository).updatePreferences(eq(secondPreferences), any(), any())
   }
@@ -101,5 +109,32 @@ class PreferencesScreenTest {
     composeTestRule.onNodeWithTag("preferencesSaveButton").performClick()
     // verify that the user goes back
     verify(mockNavHostController).goBack()
+  }
+
+  @Test
+  fun savingPreferencesNeverCallsUpdatePreferences_OnUnchangedValues() {
+    composeTestRule.setContent { PreferencesScreen(mockNavHostController, preferencesViewModel) }
+    val secondPreferences = Preferences(unitsSystem = UnitsSystem.METRIC, weight = WeightUnit.KG)
+    // check that users has default value of preferences
+    composeTestRule.onNodeWithTag("unitsSystemButton").assertTextEquals("METRIC")
+    composeTestRule.onNodeWithTag("weightUnitButton").assertTextEquals("KG")
+
+    // Simulate user changing the system of units and weight unit
+    // from (METRIC, KG) to (METRIC, KG)
+    composeTestRule.onNodeWithTag("unitsSystemButton").performClick()
+    composeTestRule.onNodeWithTag("unitsSystemMETRIC").performClick()
+    composeTestRule.onNodeWithTag("weightUnitButton").performClick()
+    composeTestRule.onNodeWithTag("weightUnitKG").performClick()
+
+    // Save the changes
+    composeTestRule.onNodeWithTag("preferencesSaveButton").performClick()
+
+    // check that users has default (IMPERIAL, LBS) of preferences
+    composeTestRule.onNodeWithTag("unitsSystemButton").assertTextEquals("METRIC")
+    composeTestRule.onNodeWithTag("weightUnitButton").assertTextEquals("KG")
+
+    // check if the the user doesn't make unnecessary update in teh firestore repository
+    verify(mockPreferencesRepository, never())
+        .updatePreferences(eq(secondPreferences), any(), any())
   }
 }

--- a/app/src/androidTest/java/com/android/sample/screen/PreferencesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/PreferencesScreenTest.kt
@@ -6,14 +6,20 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.android.sample.model.preferences.Preferences
 import com.android.sample.model.preferences.PreferencesRepository
 import com.android.sample.model.preferences.PreferencesViewModel
+import com.android.sample.model.preferences.UnitsSystem
+import com.android.sample.model.preferences.WeightUnit
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.preferences.PreferencesScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 
 class PreferencesScreenTest {
   private lateinit var mockPreferencesRepository: PreferencesRepository
@@ -68,5 +74,36 @@ class PreferencesScreenTest {
     // Verify that the selections were updated
     composeTestRule.onNodeWithTag("unitsSystemButton").assertTextEquals("IMPERIAL")
     composeTestRule.onNodeWithTag("weightUnitButton").assertTextEquals("LBS")
+  }
+
+  @Test
+  fun testUpdatePreferencesOnSaving() {
+    composeTestRule.setContent { PreferencesScreen(mockNavHostController, preferencesViewModel) }
+    val secondPreferences = Preferences(unitsSystem = UnitsSystem.IMPERIAL, weight = WeightUnit.LBS)
+
+    // First reading:
+
+    composeTestRule.onNodeWithTag("unitsSystemButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("unitsSystemButton").assertTextEquals("METRIC")
+    composeTestRule.onNodeWithTag("weightUnitButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("weightUnitButton").assertTextEquals("KG")
+
+    // Simulate user changing the system of units and weight unit
+    composeTestRule.onNodeWithTag("unitsSystemButton").performClick()
+    composeTestRule.onNodeWithTag("unitsSystemIMPERIAL").performClick()
+    composeTestRule.onNodeWithTag("weightUnitButton").performClick()
+    composeTestRule.onNodeWithTag("weightUnitLBS").performClick()
+
+    // Verify that the text selections were updated
+    composeTestRule.onNodeWithTag("unitsSystemButton").assertTextEquals("IMPERIAL")
+    composeTestRule.onNodeWithTag("weightUnitButton").assertTextEquals("LBS")
+
+    // Save the changes
+    composeTestRule.onNodeWithTag("preferencesSaveButton").performClick()
+
+    // check if the preferences were updated in the repository
+    verify(mockPreferencesRepository).updatePreferences(eq(secondPreferences), any(), any())
+    // verify that the user goes back
+    verify(mockNavHostController).goBack()
   }
 }

--- a/app/src/androidTest/java/com/android/sample/screen/PreferencesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/PreferencesScreenTest.kt
@@ -77,32 +77,30 @@ class PreferencesScreenTest {
   }
 
   @Test
-  fun testUpdatePreferencesOnSaving() {
+  fun savingPreferencesCallsUpdatePreferences() {
     composeTestRule.setContent { PreferencesScreen(mockNavHostController, preferencesViewModel) }
     val secondPreferences = Preferences(unitsSystem = UnitsSystem.IMPERIAL, weight = WeightUnit.LBS)
 
-    // First reading:
-
-    composeTestRule.onNodeWithTag("unitsSystemButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("unitsSystemButton").assertTextEquals("METRIC")
-    composeTestRule.onNodeWithTag("weightUnitButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("weightUnitButton").assertTextEquals("KG")
 
     // Simulate user changing the system of units and weight unit
+    // from (METRIC, KG) to (IMPERIAL, LBS)
     composeTestRule.onNodeWithTag("unitsSystemButton").performClick()
     composeTestRule.onNodeWithTag("unitsSystemIMPERIAL").performClick()
     composeTestRule.onNodeWithTag("weightUnitButton").performClick()
     composeTestRule.onNodeWithTag("weightUnitLBS").performClick()
-
-    // Verify that the text selections were updated
-    composeTestRule.onNodeWithTag("unitsSystemButton").assertTextEquals("IMPERIAL")
-    composeTestRule.onNodeWithTag("weightUnitButton").assertTextEquals("LBS")
 
     // Save the changes
     composeTestRule.onNodeWithTag("preferencesSaveButton").performClick()
 
     // check if the preferences were updated in the repository
     verify(mockPreferencesRepository).updatePreferences(eq(secondPreferences), any(), any())
+
+  }
+
+  @Test
+  fun savingPreferencesCallsGoBack(){
+    composeTestRule.setContent { PreferencesScreen(mockNavHostController, preferencesViewModel) }
+    composeTestRule.onNodeWithTag("preferencesSaveButton").performClick()
     // verify that the user goes back
     verify(mockNavHostController).goBack()
   }

--- a/app/src/androidTest/java/com/android/sample/screen/PreferencesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/PreferencesScreenTest.kt
@@ -81,7 +81,6 @@ class PreferencesScreenTest {
     composeTestRule.setContent { PreferencesScreen(mockNavHostController, preferencesViewModel) }
     val secondPreferences = Preferences(unitsSystem = UnitsSystem.IMPERIAL, weight = WeightUnit.LBS)
 
-
     // Simulate user changing the system of units and weight unit
     // from (METRIC, KG) to (IMPERIAL, LBS)
     composeTestRule.onNodeWithTag("unitsSystemButton").performClick()
@@ -94,11 +93,10 @@ class PreferencesScreenTest {
 
     // check if the preferences were updated in the repository
     verify(mockPreferencesRepository).updatePreferences(eq(secondPreferences), any(), any())
-
   }
 
   @Test
-  fun savingPreferencesCallsGoBack(){
+  fun savingPreferencesCallsGoBack() {
     composeTestRule.setContent { PreferencesScreen(mockNavHostController, preferencesViewModel) }
     composeTestRule.onNodeWithTag("preferencesSaveButton").performClick()
     // verify that the user goes back

--- a/app/src/main/java/com/android/sample/model/preferences/PreferencesRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/preferences/PreferencesRepositoryFirestore.kt
@@ -5,12 +5,11 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
-import com.squareup.moshi.JsonDataException
-import com.squareup.moshi.JsonEncodingException
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
-class PreferencesRepositoryFirestore(private val db: FirebaseFirestore) : PreferencesRepository {
+open class PreferencesRepositoryFirestore(private val db: FirebaseFirestore) :
+    PreferencesRepository {
 
   val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
 
@@ -72,7 +71,7 @@ class PreferencesRepositoryFirestore(private val db: FirebaseFirestore) : Prefer
         .addOnFailureListener { e -> onFailure(e) }
   }
 
-  private fun documentSnapshotToPreferences(doc: DocumentSnapshot): Preferences {
+  open fun documentSnapshotToPreferences(doc: DocumentSnapshot): Preferences {
     if (!doc.exists()) {
       Log.e("DEB", "The document does not exist")
       return PreferencesViewModel.defaultPreferences
@@ -84,14 +83,8 @@ class PreferencesRepositoryFirestore(private val db: FirebaseFirestore) : Prefer
       val prefs = preferencesAdapter.fromJson(json)
 
       return prefs ?: throw IllegalArgumentException("Conversion error in Preferences")
-    } catch (e: JsonDataException) {
-      Log.e("Moshi", "Data error JSON : ${e.message}")
-      throw e
-    } catch (e: JsonEncodingException) {
-      Log.e("Moshi", "Encoding error JSON : ${e.message}")
-      throw e
-    } catch (e: Exception) {
-      Log.e("Moshi", "Conversion error : ${e.message}")
+    } catch (e: Error) {
+      Log.e("Moshi", "Moshi error : ${e.message}")
       throw e
     }
   }

--- a/app/src/main/java/com/android/sample/model/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/preferences/PreferencesViewModel.kt
@@ -20,6 +20,7 @@ class PreferencesViewModel(private val repository: PreferencesRepository) : View
   }
 
   fun updatePreferences(prefs: Preferences) {
+    if (prefs == preferences_.value) return
     repository.updatePreferences(prefs, onSuccess = { getPreferences() }, onFailure = {})
   }
 

--- a/app/src/main/java/com/android/sample/ui/preferences/PreferencesScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/preferences/PreferencesScreen.kt
@@ -32,8 +32,9 @@ fun PreferencesScreen(
   val context = LocalContext.current
 
   val preferences =
-      preferencesViewModel.preferences.collectAsState().value
-          ?: run { throw IllegalStateException("Preferences should not be null.") }
+      requireNotNull(preferencesViewModel.preferences.collectAsState().value) {
+        "Preferences should not be null."
+      }
 
   var unitsSystem by remember { mutableStateOf(preferences.unitsSystem) }
   var weightUnit by remember { mutableStateOf(preferences.weight) }

--- a/app/src/test/java/com/android/sample/model/preferences/PreferencesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/preferences/PreferencesRepositoryFirestoreTest.kt
@@ -12,6 +12,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import junit.framework.TestCase.fail
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
@@ -124,7 +125,7 @@ class PreferencesRepositoryFirestoreTest {
 
     val result = preferencesRepositoryFirestore.documentSnapshotToPreferences(mockDocumentSnapshot)
 
-    assert(result == PreferencesViewModel.defaultPreferences)
+    assertEquals(result, PreferencesViewModel.defaultPreferences)
   }
 
   @Test

--- a/app/src/test/java/com/android/sample/model/preferences/PreferencesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/preferences/PreferencesRepositoryFirestoreTest.kt
@@ -12,6 +12,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import junit.framework.TestCase.fail
 import org.junit.After
+import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -114,5 +115,28 @@ class PreferencesRepositoryFirestoreTest {
 
     // Verify that the document reference's delete method was called
     verify(mockDocumentReference).delete()
+  }
+
+  @Test
+  fun documentSnapshotToPreferences_ReturnsDefaultPreferencesIfNotFoundOnFIreStore() {
+    val mockDocumentSnapshot = mock(DocumentSnapshot::class.java)
+    `when`(mockDocumentSnapshot.exists()).thenReturn(false)
+
+    val result = preferencesRepositoryFirestore.documentSnapshotToPreferences(mockDocumentSnapshot)
+
+    assert(result == PreferencesViewModel.defaultPreferences)
+  }
+
+  @Test
+  fun documentSnapshotToPreferences_throwsErrorIfPrefsIsNull() {
+    // Arrange
+    val mockDocumentSnapshot = mock(DocumentSnapshot::class.java)
+    `when`(mockDocumentSnapshot.exists()).thenReturn(true)
+    `when`(mockDocumentSnapshot.data).thenReturn(null) // Simulate null data
+
+    // Act & Assert
+    assertThrows(IllegalArgumentException::class.java) {
+      preferencesRepositoryFirestore.documentSnapshotToPreferences(mockDocumentSnapshot)
+    }
   }
 }

--- a/app/src/test/java/com/android/sample/model/preferences/PreferencesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/sample/model/preferences/PreferencesRepositoryFirestoreTest.kt
@@ -118,7 +118,7 @@ class PreferencesRepositoryFirestoreTest {
   }
 
   @Test
-  fun documentSnapshotToPreferences_ReturnsDefaultPreferencesIfNotFoundOnFIreStore() {
+  fun documentSnapshotToPreferences_ReturnsDefaultPreferencesIfNotFoundOnFireStore() {
     val mockDocumentSnapshot = mock(DocumentSnapshot::class.java)
     `when`(mockDocumentSnapshot.exists()).thenReturn(false)
 

--- a/app/src/test/java/com/android/sample/ui/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/android/sample/ui/navigation/NavigationActionsTest.kt
@@ -1,6 +1,7 @@
 package com.android.sample.ui.navigation
 
 import androidx.navigation.NavDestination
+import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
 import org.hamcrest.CoreMatchers.`is`
@@ -11,6 +12,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 
 class NavigationActionsTest {
@@ -22,7 +24,11 @@ class NavigationActionsTest {
   @Before
   fun setUp() {
     navigationDestination = mock(NavDestination::class.java)
+    val navGraph = mock(NavGraph::class.java)
+    `when`(navGraph.startDestinationId).thenReturn(0) // Mock the startDestinationId
     navHostController = mock(NavHostController::class.java)
+    `when`(navHostController.graph)
+        .thenReturn(navGraph) // Set the mocked NavGraph to the NavHostController
     navigationActions = NavigationActions(navHostController)
   }
 
@@ -47,5 +53,36 @@ class NavigationActionsTest {
     `when`(navigationDestination.route).thenReturn(Route.MAIN)
 
     assertThat(navigationActions.currentRoute(), `is`(Route.MAIN))
+  }
+
+  @Test
+  fun navigateToTopLevelDestinationClearsBackStack() {
+    val destination = TopLevelDestinations.MAIN
+    navigationActions.navigateTo(destination)
+
+    val captor = argumentCaptor<NavOptionsBuilder.() -> Unit>()
+    verify(navHostController).navigate(eq(destination.route), captor.capture())
+
+    val navOptionsBuilder = NavOptionsBuilder()
+    captor.firstValue.invoke(navOptionsBuilder)
+    assertThat(navOptionsBuilder.popUpTo, `is`(0))
+    assertThat(navOptionsBuilder.launchSingleTop, `is`(true))
+    assertThat(navOptionsBuilder.restoreState, `is`(true))
+  }
+
+  @Test
+  fun navigateToTopLevelDestinationClearsBackStackWithAUTH_PATH() {
+    val destinationMocked = mock(TopLevelDestination::class.java)
+    `when`(destinationMocked.route).thenReturn(Route.AUTH)
+    navigationActions.navigateTo(destinationMocked)
+
+    val captor = argumentCaptor<NavOptionsBuilder.() -> Unit>()
+    verify(navHostController).navigate(eq(destinationMocked.route), captor.capture())
+
+    val navOptionsBuilder = NavOptionsBuilder()
+    captor.firstValue.invoke(navOptionsBuilder)
+    assertThat(navOptionsBuilder.popUpTo, `is`(0))
+    assertThat(navOptionsBuilder.launchSingleTop, `is`(true))
+    assertThat(navOptionsBuilder.restoreState, `is`(false))
   }
 }


### PR DESCRIPTION
# Added Tests:
### NavigationActionsTest.kt:
- navigateToTopLevelDestinationClearsBackStack()
- navigateToTopLevelDestinationClearsBackStackWithAUTH_PATH()

### PreferenceScreenTest.kt:
- savingPreferencesCallsGoBack()
- savingPreferencesCallsUpdatePreferences()

### PreferencesRepositoryFirestoreTest.kt:
- documentSnapshotToPreferences_ReturnsDefaultPreferencesIfNotFoundOnFireStore()
- documentSnapshotToPreferences_throwsErrorIfPrefsIsNull()

# Summary:
This PR mainly aims at improving the line coverage of the project.
