### PR TITLE
Make the app remember that the user has Logged in and logged Out

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -195,7 +195,9 @@ dependencies {
     testImplementation(libs.mockk)
     androidTestImplementation(libs.mockito.android)
     androidTestImplementation(libs.mockito.kotlin)
-
+    configurations.configureEach {
+        exclude(group = "com.google.protobuf", module = "protobuf-lite")
+    }
 }
 
 tasks.withType<Test> {

--- a/app/src/main/java/com/android/sample/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/SignIn.kt
@@ -17,7 +17,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -45,6 +49,8 @@ import kotlinx.coroutines.tasks.await
 fun SignInScreen(navigationActions: NavigationActions) {
   val context = LocalContext.current
 
+  val user by remember { mutableStateOf(Firebase.auth.currentUser) }
+
   val launcher =
       rememberFirebaseAuthLauncher(
           onAuthComplete = { result ->
@@ -59,48 +65,53 @@ fun SignInScreen(navigationActions: NavigationActions) {
   val token = stringResource(com.android.sample.R.string.default_web_client_id)
   // The main container for the screen
   // A surface container using the 'background' color from the theme
-  Scaffold(
-      modifier = Modifier.fillMaxSize(),
-      content = { padding ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(padding),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-          // App Logo Image
-          Image(
-              painter = painterResource(id = com.android.sample.R.drawable.logo),
-              contentDescription = "App Logo",
-              modifier = Modifier.size(250.dp))
+  if (user == null) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        content = { padding ->
+          Column(
+              modifier = Modifier.fillMaxSize().padding(padding),
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.Center,
+          ) {
+            // App Logo Image
+            Image(
+                painter = painterResource(id = com.android.sample.R.drawable.logo),
+                contentDescription = "App Logo",
+                modifier = Modifier.size(250.dp))
 
-          Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-          // Welcome Text
-          Text(
-              modifier = Modifier.testTag("loginTitle"),
-              text = "Welcome",
-              style =
-                  MaterialTheme.typography.headlineLarge.copy(fontSize = 57.sp, lineHeight = 64.sp),
-              fontWeight = FontWeight.Bold,
-              // center the text
+            // Welcome Text
+            Text(
+                modifier = Modifier.testTag("loginTitle"),
+                text = "Welcome",
+                style =
+                    MaterialTheme.typography.headlineLarge.copy(
+                        fontSize = 57.sp, lineHeight = 64.sp),
+                fontWeight = FontWeight.Bold,
+                // center the text
 
-              textAlign = TextAlign.Center)
+                textAlign = TextAlign.Center)
 
-          Spacer(modifier = Modifier.height(48.dp))
+            Spacer(modifier = Modifier.height(48.dp))
 
-          // Authenticate With Google Button
-          GoogleSignInButton(
-              onSignInClick = {
-                val gso =
-                    GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                        .requestIdToken(token)
-                        .requestEmail()
-                        .build()
-                val googleSignInClient = GoogleSignIn.getClient(context, gso)
-                launcher.launch(googleSignInClient.signInIntent)
-              })
-        }
-      })
+            // Authenticate With Google Button
+            GoogleSignInButton(
+                onSignInClick = {
+                  val gso =
+                      GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                          .requestIdToken(token)
+                          .requestEmail()
+                          .build()
+                  val googleSignInClient = GoogleSignIn.getClient(context, gso)
+                  launcher.launch(googleSignInClient.signInIntent)
+                })
+          }
+        })
+  } else {
+    navigationActions.navigateTo(TopLevelDestinations.MAIN)
+  }
 }
 
 @Composable

--- a/app/src/main/java/com/android/sample/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/settings/SettingsScreen.kt
@@ -17,9 +17,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.sample.R
 import com.android.sample.ui.composables.ArrowBack
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.Screen
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.firebase.auth.FirebaseAuth
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -83,9 +87,21 @@ fun SettingsScreen(navigationActions: NavigationActions) {
                   }
 
               // Logout button
+              // Code taken from :
+              // https://stackoverflow.com/questions/72563673/google-authentication-with-firebase-and-jetpack-compose
               Button(
                   onClick = {
                     FirebaseAuth.getInstance().signOut() // Sign out from Firebase
+                    val gso =
+                        GoogleSignInOptions.Builder(
+                                GoogleSignInOptions.DEFAULT_SIGN_IN) // Sign out from Google
+                            .requestIdToken(context.getString(R.string.default_web_client_id))
+                            .requestEmail()
+                            .build()
+                    val googleSignInClient: GoogleSignInClient =
+                        GoogleSignIn.getClient(context, gso)
+                    googleSignInClient.signOut()
+
                     navigationActions.navigateTo("Auth Screen") // Navigate back to Auth screen
                     Toast.makeText(context, "Logged out successfully", Toast.LENGTH_SHORT).show()
                   },


### PR DESCRIPTION
## **Summary:**
This PR allows the app : 
- to  remember when the User has logged-in ie : Once the user has logged-in, the Auth. screen is skipped automatically at the start of the app.
- to ask again with wich google account  the user wants to log-in once he/she has logged out. 

Modified Files:
- SignIn.kt
- SettingScreen.kt
- build.gradle.kts


### SignIn.kt
- Conditioning the apparition of the auth. screen based on the Firestore local cache


### SettingsScreen.kt
- Make the app logging out of google services so that the app ask the user wich acount he want to login with after a logout

### build.gradle.kts
- Remove conflicting imports (protobuf-lite)


