### PR TITLE
Fix/Move Profile Image Upload Logic to ViewModel and Add URI Parsing Checks

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/authentication/EditAccountTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/authentication/EditAccountTest.kt
@@ -5,13 +5,11 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.android.sample.model.userAccount.*
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.viewmodel.UserAccountViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class EditAccountScreenTest {
 
   private lateinit var userAccountRepository: UserAccountRepository

--- a/app/src/main/java/com/android/sample/model/userAccount/UserAccountViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/userAccount/UserAccountViewModel.kt
@@ -1,5 +1,6 @@
 package com.android.sample.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.android.sample.model.userAccount.UserAccount
@@ -8,6 +9,8 @@ import com.android.sample.model.userAccount.UserAccountRepositoryFirestore
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
+import java.util.UUID
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -49,6 +52,25 @@ open class UserAccountViewModel(private val repository: UserAccountRepository) :
   fun updateUserAccount(userAccount: UserAccount) {
     repository.updateUserAccount(
         userAccount, onSuccess = { getUserAccount(userAccount.userId) }, onFailure = {})
+  }
+
+  fun uploadProfileImage(
+      uri: Uri,
+      userId: String,
+      onSuccess: (String) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val storageRef = FirebaseStorage.getInstance().reference
+    val profileImageRef = storageRef.child("profile_images/${userId}/${UUID.randomUUID()}.jpg")
+
+    profileImageRef
+        .putFile(uri)
+        .addOnSuccessListener {
+          profileImageRef.downloadUrl.addOnSuccessListener { downloadUri ->
+            onSuccess(downloadUri.toString())
+          }
+        }
+        .addOnFailureListener { exception -> onFailure(exception) }
   }
 
   // Factory for creating instances of the ViewModel

--- a/app/src/main/java/com/android/sample/ui/authentication/AddAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/AddAccount.kt
@@ -31,10 +31,8 @@ import com.android.sample.viewmodel.UserAccountViewModel
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
-import com.google.firebase.storage.FirebaseStorage
 import java.util.Calendar
 import java.util.GregorianCalendar
-import java.util.UUID
 
 @Composable
 fun AddAccount(
@@ -63,6 +61,7 @@ fun AddAccount(
 
   // Retrieve current user UID from Firebase Auth
   val actualUserId = userId ?: return // Ensure user is signed in
+  val context = LocalContext.current
 
   if (accountExists) {
     LaunchedEffect(userAccount) {
@@ -82,13 +81,22 @@ fun AddAccount(
               "${calendar.get(Calendar.DAY_OF_MONTH)}/${calendar.get(Calendar.MONTH) + 1}/${calendar.get(
                             Calendar.YEAR)}"
             }
-        profileImageUri = Uri.parse(it.profileImageUrl)
-        originalProfileImageUri = Uri.parse(it.profileImageUrl) // Set the original URI
+        // Check for valid URI before assigning it
+        try {
+          val parsedUri = Uri.parse(it.profileImageUrl)
+          if (parsedUri != null && parsedUri.toString().isNotBlank()) {
+            profileImageUri = parsedUri
+            originalProfileImageUri = parsedUri // Set the original URI if valid
+          }
+        } catch (e: Exception) {
+          Toast.makeText(context, "Invalid profile image URL", Toast.LENGTH_SHORT).show()
+          // You might also set profileImageUri to null or a default URI if needed
+          profileImageUri = null
+          originalProfileImageUri = null
+        }
       }
     }
   }
-
-  val context = LocalContext.current
 
   // Initialize the image picker launcher outside of the clickable scope
   val imagePickerLauncher =
@@ -305,7 +313,7 @@ fun saveAccount(
               profileImageUrl = profileImageUrl)
 
       if (profileImageUri != null && profileImageUri != originalProfileImageUri) {
-        uploadProfileImage(
+        userAccountViewModel.uploadProfileImage(
             profileImageUri,
             userId,
             onSuccess = { downloadUrl ->
@@ -417,23 +425,4 @@ fun <T> DropdownMenuButton(
       }
     }
   }
-}
-
-val storageRef = FirebaseStorage.getInstance().reference
-
-fun uploadProfileImage(
-    uri: Uri,
-    userId: String,
-    onSuccess: (String) -> Unit,
-    onFailure: (Exception) -> Unit
-) {
-  val profileImageRef = storageRef.child("profile_images/${userId}/${UUID.randomUUID()}.jpg")
-  profileImageRef
-      .putFile(uri)
-      .addOnSuccessListener {
-        profileImageRef.downloadUrl.addOnSuccessListener { downloadUri ->
-          onSuccess(downloadUri.toString())
-        }
-      }
-      .addOnFailureListener { exception -> onFailure(exception) }
 }

--- a/app/src/main/java/com/android/sample/ui/authentication/AddAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/AddAccount.kt
@@ -90,7 +90,6 @@ fun AddAccount(
           }
         } catch (e: Exception) {
           Toast.makeText(context, "Invalid profile image URL", Toast.LENGTH_SHORT).show()
-          // You might also set profileImageUri to null or a default URI if needed
           profileImageUri = null
           originalProfileImageUri = null
         }


### PR DESCRIPTION
### **Summary**

This PR refactors the AddAccount screen to move the Firebase Storage image upload logic into the UserAccountViewModel. Additionally, a URI parsing check was added to handle potential invalid profile image URLs more gracefully as mentioned in a comment in a previous PR.

### **Changes Made**
1. UserAccountViewModel.kt:
	•	Added uploadProfileImage function to manage profile image uploads to Firebase Storage, centralizing this logic within the ViewModel.
	•	Updated necessary imports for Firebase Storage.
2. AddAccount.kt:
	•	Replaced the direct call to uploadProfileImage with the new ViewModel method, simplifying the UI code.
	•	Added a URI parsing check within LaunchedEffect to validate profileImageUrl. If parsing fails, a fallback and user notification are provided.
