### PR TITLE
Fix/Account creation logic

### DIFF
--- a/app/src/main/java/com/android/sample/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/SignIn.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -57,6 +59,7 @@ fun SignInScreen(
   val context = LocalContext.current
   val scope = rememberCoroutineScope()
   val user by remember { mutableStateOf(Firebase.auth.currentUser) }
+  val userAccount by userAccountViewModel.userAccount.collectAsState(initial = null)
 
   val launcher =
       rememberFirebaseAuthLauncher(
@@ -136,7 +139,14 @@ fun SignInScreen(
           }
         })
   } else {
-    navigationActions.navigateTo(TopLevelDestinations.MAIN)
+    // When user is signed in, check if they have an account
+    LaunchedEffect(userAccount) {
+      if (userAccount != null) {
+        navigationActions.navigateTo(TopLevelDestinations.MAIN)
+      } else {
+        navigationActions.navigateTo(Screen.ADD_ACCOUNT)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### **Summary**

This PR introduces a check in the SignInScreen to ensure that if a user is already signed in but somehow didn't fill out the AddAccount fields, they are directed to the AddAccount screen instead of the main screen. This adjustment enhances the onboarding flow by prompting users without accounts to create one, even if they are authenticated.

**Implementation Details**
- Added a conditional check in SignInScreen to verify if a signed-in user has an associated account.
- Redirects signed-in users without an account to the AddAccount screen to complete their profile setup.

This small change improves the user experience for returning users who may be signed in but have not completed account creation.