### PR TITLE
Fix/Assign detail automatically to exercises

### DIFF
--- a/app/src/androidTest/java/com/android/sample/screen/WorkoutCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/WorkoutCreationScreenTest.kt
@@ -2,11 +2,13 @@ package com.android.sample.screen
 
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.android.sample.model.workout.BodyWeightWorkout
+import com.android.sample.model.workout.ExerciseDetail
 import com.android.sample.model.workout.ExerciseType
 import com.android.sample.model.workout.WorkoutRepository
 import com.android.sample.model.workout.WorkoutType
@@ -122,11 +124,6 @@ class WorkoutCreationScreenTest {
         .assertTextEquals("Selected Exercise: ${ExerciseType.PUSH_UPS}")
 
     // check that PushUps is a repetition based exercise
-
-    // composeTestRule.onNodeWithTag("durationTextField").assertIsDisplayed()
-    // composeTestRule.onNodeWithTag("setsTextField").assertIsDisplayed()
-    // composeTestRule.onNodeWithTag("repetitionBasedButton").performClick()
-    composeTestRule.onNodeWithTag("repetitionsTextField").assertIsDisplayed()
     // check default value
     composeTestRule.onNodeWithTag("repetitionsTextField").assertIsDisplayed()
     composeTestRule
@@ -136,5 +133,119 @@ class WorkoutCreationScreenTest {
     composeTestRule.onNodeWithTag("addExerciseConfirmButton").performClick()
     composeTestRule.onNodeWithTag("exerciseCard").assertIsDisplayed()
     composeTestRule.onNodeWithTag("saveButton").assertIsDisplayed().assertHasClickAction()
+  }
+
+  @Test
+  fun createDefaultBodyWeightExerciseWhenNoChangesRequested() {
+    composeTestRule.setContent {
+      WorkoutCreationScreen(
+          navigationActions = mockNavHostController,
+          workoutType = WorkoutType.BODY_WEIGHT,
+          workoutViewModel = mockBodyWeightWorkoutViewModel,
+          isImported = false)
+    }
+
+    composeTestRule.onNodeWithTag("nextButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithTag("nextButton").assertTextEquals("Next")
+    composeTestRule.onNodeWithTag("nextButton").performClick()
+
+    composeTestRule.onNodeWithTag("addExerciseButton").performClick()
+
+    ExerciseType.entries
+        .filter { it.workoutType == WorkoutType.BODY_WEIGHT }
+        .forEach { exerciseType ->
+          composeTestRule.onNodeWithTag("selectExerciseTypeButton").performClick()
+          // Select the exercise
+          composeTestRule.onNodeWithTag("exerciseType${exerciseType.name}").performClick()
+          composeTestRule
+              .onNodeWithTag("selectedExerciseType")
+              .assertTextEquals("Selected Exercise: ${exerciseType.toString()}")
+
+          // check that default value are displayed
+          when (exerciseType.detail) {
+            is ExerciseDetail.RepetitionBased -> {
+              composeTestRule
+                  .onNodeWithTag("repetitionsTextField")
+                  .assertIsDisplayed()
+                  .assertTextContains(
+                      (exerciseType.detail as ExerciseDetail.RepetitionBased)
+                          .repetitions
+                          .toString()) // default value of the repetition
+            }
+            is ExerciseDetail.TimeBased -> {
+              composeTestRule
+                  .onNodeWithTag("durationTextField")
+                  .assertIsDisplayed()
+                  .assertTextContains(
+                      (exerciseType.detail as ExerciseDetail.TimeBased)
+                          .durationInSeconds
+                          .toString()) // default value of the duration in second
+              composeTestRule
+                  .onNodeWithTag("setsTextField")
+                  .assertIsDisplayed()
+                  .assertTextContains(
+                      (exerciseType.detail as ExerciseDetail.TimeBased)
+                          .sets
+                          .toString()) // default value of the duration in second
+            }
+          }
+        }
+  }
+
+  @Test
+  fun createDefaultYogaExerciseWhenNoChangesRequested() {
+    composeTestRule.setContent {
+      WorkoutCreationScreen(
+          navigationActions = mockNavHostController,
+          workoutType = WorkoutType.YOGA,
+          workoutViewModel = mockYogaWorkoutViewModel,
+          isImported = false)
+    }
+
+    composeTestRule.onNodeWithTag("nextButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithTag("nextButton").assertTextEquals("Next")
+    composeTestRule.onNodeWithTag("nextButton").performClick()
+
+    composeTestRule.onNodeWithTag("addExerciseButton").performClick()
+
+    ExerciseType.entries
+        .filter { it.workoutType == WorkoutType.YOGA }
+        .forEach { exerciseType ->
+          composeTestRule.onNodeWithTag("selectExerciseTypeButton").performClick()
+          // Select the  exercise
+          composeTestRule.onNodeWithTag("exerciseType${exerciseType.name}").performClick()
+          composeTestRule
+              .onNodeWithTag("selectedExerciseType")
+              .assertTextEquals("Selected Exercise: ${exerciseType.toString()}")
+
+          // check that default value are displayed
+          when (exerciseType.detail) {
+            is ExerciseDetail.RepetitionBased -> {
+              composeTestRule
+                  .onNodeWithTag("repetitionsTextField")
+                  .assertIsDisplayed()
+                  .assertTextContains(
+                      (exerciseType.detail as ExerciseDetail.RepetitionBased)
+                          .repetitions
+                          .toString()) // default value of the repetition
+            }
+            is ExerciseDetail.TimeBased -> {
+              composeTestRule
+                  .onNodeWithTag("durationTextField")
+                  .assertIsDisplayed()
+                  .assertTextContains(
+                      (exerciseType.detail as ExerciseDetail.TimeBased)
+                          .durationInSeconds
+                          .toString()) // default value of the duration in second
+              composeTestRule
+                  .onNodeWithTag("setsTextField")
+                  .assertIsDisplayed()
+                  .assertTextContains(
+                      (exerciseType.detail as ExerciseDetail.TimeBased)
+                          .sets
+                          .toString()) // default value of the duration in second
+            }
+          }
+        }
   }
 }

--- a/app/src/androidTest/java/com/android/sample/screen/WorkoutCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/WorkoutCreationScreenTest.kt
@@ -78,7 +78,6 @@ class WorkoutCreationScreenTest {
         .onNodeWithTag("selectedExerciseType")
         .assertTextEquals("Selected Exercise: ${ExerciseType.SUN_SALUTATION}")
 
-
     composeTestRule.onNodeWithTag("durationTextField").assertIsDisplayed()
     composeTestRule.onNodeWithTag("setsTextField").assertIsDisplayed()
     composeTestRule
@@ -122,14 +121,13 @@ class WorkoutCreationScreenTest {
         .onNodeWithTag("selectedExerciseType")
         .assertTextEquals("Selected Exercise: ${ExerciseType.PUSH_UPS}")
 
-    //check that PushUps is a repetition based exercise
+    // check that PushUps is a repetition based exercise
 
-
-    //composeTestRule.onNodeWithTag("durationTextField").assertIsDisplayed()
-    //composeTestRule.onNodeWithTag("setsTextField").assertIsDisplayed()
-    //composeTestRule.onNodeWithTag("repetitionBasedButton").performClick()
+    // composeTestRule.onNodeWithTag("durationTextField").assertIsDisplayed()
+    // composeTestRule.onNodeWithTag("setsTextField").assertIsDisplayed()
+    // composeTestRule.onNodeWithTag("repetitionBasedButton").performClick()
     composeTestRule.onNodeWithTag("repetitionsTextField").assertIsDisplayed()
-    //check default value
+    // check default value
     composeTestRule.onNodeWithTag("repetitionsTextField").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("addExerciseConfirmButton")

--- a/app/src/androidTest/java/com/android/sample/screen/WorkoutCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/screen/WorkoutCreationScreenTest.kt
@@ -77,16 +77,10 @@ class WorkoutCreationScreenTest {
     composeTestRule
         .onNodeWithTag("selectedExerciseType")
         .assertTextEquals("Selected Exercise: ${ExerciseType.SUN_SALUTATION}")
-    composeTestRule.onNodeWithTag("timeBasedButton").assertIsDisplayed().assertHasClickAction()
-    composeTestRule
-        .onNodeWithTag("repetitionBasedButton")
-        .assertIsDisplayed()
-        .assertHasClickAction()
-    composeTestRule.onNodeWithTag("timeBasedButton").performClick()
+
+
     composeTestRule.onNodeWithTag("durationTextField").assertIsDisplayed()
     composeTestRule.onNodeWithTag("setsTextField").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("repetitionBasedButton").performClick()
-    composeTestRule.onNodeWithTag("repetitionsTextField").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("addExerciseConfirmButton")
         .assertIsDisplayed()
@@ -127,15 +121,15 @@ class WorkoutCreationScreenTest {
     composeTestRule
         .onNodeWithTag("selectedExerciseType")
         .assertTextEquals("Selected Exercise: ${ExerciseType.PUSH_UPS}")
-    composeTestRule.onNodeWithTag("timeBasedButton").assertIsDisplayed().assertHasClickAction()
-    composeTestRule
-        .onNodeWithTag("repetitionBasedButton")
-        .assertIsDisplayed()
-        .assertHasClickAction()
-    composeTestRule.onNodeWithTag("timeBasedButton").performClick()
-    composeTestRule.onNodeWithTag("durationTextField").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("setsTextField").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("repetitionBasedButton").performClick()
+
+    //check that PushUps is a repetition based exercise
+
+
+    //composeTestRule.onNodeWithTag("durationTextField").assertIsDisplayed()
+    //composeTestRule.onNodeWithTag("setsTextField").assertIsDisplayed()
+    //composeTestRule.onNodeWithTag("repetitionBasedButton").performClick()
+    composeTestRule.onNodeWithTag("repetitionsTextField").assertIsDisplayed()
+    //check default value
     composeTestRule.onNodeWithTag("repetitionsTextField").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("addExerciseConfirmButton")

--- a/app/src/main/java/com/android/sample/model/workout/Exercise.kt
+++ b/app/src/main/java/com/android/sample/model/workout/Exercise.kt
@@ -2,19 +2,20 @@ package com.android.sample.model.workout
 
 data class Exercise(val id: String, val type: ExerciseType, val detail: ExerciseDetail) {}
 
-enum class ExerciseType(val workoutType: WorkoutType,val detail: ExerciseDetail) {
-DOWNWARD_DOG(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(30, sets = 3)),
-TREE_POSE(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(30, sets = 3)),
-SUN_SALUTATION(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(60, sets = 2)),
-WARRIOR_II(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(30, sets = 3)),
-PUSH_UPS(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.RepetitionBased(10)),
-SQUATS(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.RepetitionBased(15)),
-PLANK(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.TimeBased(60, sets = 1)),
-CHAIR(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.TimeBased(60, sets = 1)),
-JUMPING_JACKS(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(20)),
-LEG_SWINGS(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(15)),
-ARM_CIRCLES(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(20)),
-ARM_WRIST_CIRCLES(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(20));
+enum class ExerciseType(val workoutType: WorkoutType, val detail: ExerciseDetail) {
+  DOWNWARD_DOG(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(30, sets = 3)),
+  TREE_POSE(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(30, sets = 3)),
+  SUN_SALUTATION(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(60, sets = 2)),
+  WARRIOR_II(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(30, sets = 3)),
+  PUSH_UPS(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.RepetitionBased(10)),
+  SQUATS(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.RepetitionBased(15)),
+  PLANK(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.TimeBased(60, sets = 1)),
+  CHAIR(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.TimeBased(60, sets = 1)),
+  JUMPING_JACKS(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(20)),
+  LEG_SWINGS(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(15)),
+  ARM_CIRCLES(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(20)),
+  ARM_WRIST_CIRCLES(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(20));
+
   fun getInstruction(): String {
     return when (this) {
       DOWNWARD_DOG -> "Hands shoulder-width, feet hip-width, form an inverted V."

--- a/app/src/main/java/com/android/sample/model/workout/Exercise.kt
+++ b/app/src/main/java/com/android/sample/model/workout/Exercise.kt
@@ -2,20 +2,19 @@ package com.android.sample.model.workout
 
 data class Exercise(val id: String, val type: ExerciseType, val detail: ExerciseDetail) {}
 
-enum class ExerciseType(val workoutType: WorkoutType) {
-  DOWNWARD_DOG(WorkoutType.YOGA),
-  TREE_POSE(WorkoutType.YOGA),
-  SUN_SALUTATION(WorkoutType.YOGA),
-  WARRIOR_II(WorkoutType.YOGA),
-  PUSH_UPS(WorkoutType.BODY_WEIGHT),
-  SQUATS(WorkoutType.BODY_WEIGHT),
-  PLANK(WorkoutType.BODY_WEIGHT),
-  CHAIR(WorkoutType.BODY_WEIGHT),
-  JUMPING_JACKS(WorkoutType.WARMUP),
-  LEG_SWINGS(WorkoutType.WARMUP),
-  ARM_CIRCLES(WorkoutType.WARMUP),
-  ARM_WRIST_CIRCLES(WorkoutType.WARMUP);
-
+enum class ExerciseType(val workoutType: WorkoutType,val detail: ExerciseDetail) {
+DOWNWARD_DOG(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(30, sets = 3)),
+TREE_POSE(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(30, sets = 3)),
+SUN_SALUTATION(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(60, sets = 2)),
+WARRIOR_II(WorkoutType.YOGA, detail = ExerciseDetail.TimeBased(30, sets = 3)),
+PUSH_UPS(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.RepetitionBased(10)),
+SQUATS(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.RepetitionBased(15)),
+PLANK(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.TimeBased(60, sets = 1)),
+CHAIR(WorkoutType.BODY_WEIGHT, detail = ExerciseDetail.TimeBased(60, sets = 1)),
+JUMPING_JACKS(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(20)),
+LEG_SWINGS(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(15)),
+ARM_CIRCLES(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(20)),
+ARM_WRIST_CIRCLES(WorkoutType.WARMUP, detail = ExerciseDetail.RepetitionBased(20));
   fun getInstruction(): String {
     return when (this) {
       DOWNWARD_DOG -> "Hands shoulder-width, feet hip-width, form an inverted V."

--- a/app/src/main/java/com/android/sample/ui/composables/ExerciseCard.kt
+++ b/app/src/main/java/com/android/sample/ui/composables/ExerciseCard.kt
@@ -92,7 +92,7 @@ fun ExerciseDetailCard(detail: ExerciseDetail, onClick: () -> Unit) {
                       )
                   Spacer(modifier = Modifier.width(4.dp))
                   Text(
-                      text = "${detail.durationInSeconds / 60}′ X ${detail.sets}",
+                      text = "${formatTime(detail.durationInSeconds)} X ${detail.sets}",
                       fontSize = 14.sp,
                       color = Black // Black text
                       )
@@ -114,4 +114,21 @@ fun ExerciseDetailCard(detail: ExerciseDetail, onClick: () -> Unit) {
               }
             }
       }
+}
+
+
+fun formatTime(time: Int): String {
+  val minutes = time / 60
+  val seconds = time % 60
+  val secondSimbol = "s"
+  val minuteSimbol = "m"
+  return if (minutes == 0 && seconds > 0) {
+    "${seconds}${secondSimbol}"
+  } else if (seconds == 0 && minutes > 0) {
+    "${minutes}${minuteSimbol}"
+  } else if (minutes == 0 && seconds == 0) {
+    "0${minuteSimbol}0${secondSimbol}"
+  } else {
+    "${minutes}${minuteSimbol}${seconds}${secondSimbol}"
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/composables/ExerciseCard.kt
+++ b/app/src/main/java/com/android/sample/ui/composables/ExerciseCard.kt
@@ -116,7 +116,6 @@ fun ExerciseDetailCard(detail: ExerciseDetail, onClick: () -> Unit) {
       }
 }
 
-
 fun formatTime(time: Int): String {
   val minutes = time / 60
   val seconds = time % 60

--- a/app/src/main/java/com/android/sample/ui/workout/WorkoutCreationScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/workout/WorkoutCreationScreen.kt
@@ -98,6 +98,11 @@ fun WorkoutCreationScreen(
   var selectedExerciseType by remember { mutableStateOf<ExerciseType?>(null) }
   var exerciseDetail by remember { mutableStateOf<ExerciseDetail?>(null) }
   var isDropdownExpanded by remember { mutableStateOf(false) }
+  // Time-based exercise details to be shown in the input fields
+  var durationInSeconds_input by remember { mutableStateOf("") }
+  var sets_input by remember { mutableStateOf("") }
+  var repetitions_input by remember { mutableStateOf("") }
+
 
   Scaffold(
       topBar = {
@@ -336,56 +341,62 @@ fun WorkoutCreationScreen(
                   "Selected Exercise: ${selectedExerciseType.toString()}",
                   modifier = Modifier.testTag("selectedExerciseType"))
               Text("Goal")
-              Row {
-                Button(
-                    onClick = { exerciseDetail = ExerciseDetail.TimeBased(0, 0) },
-                    modifier = Modifier.testTag("timeBasedButton")) {
-                      Text("TimeBased")
-                    }
-                Button(
-                    onClick = { exerciseDetail = ExerciseDetail.RepetitionBased(0) },
-                    modifier = Modifier.testTag("repetitionBasedButton")) {
-                      Text("RepetitionBased")
-                    }
-              }
-              when (exerciseDetail) {
+
+              val seletedExerciseTypeDetail = selectedExerciseType!!.detail
+
+              when (seletedExerciseTypeDetail) {
                 is ExerciseDetail.TimeBased -> {
+                  durationInSeconds_input = (exerciseDetail as? ExerciseDetail.TimeBased)?.durationInSeconds.toString()
+                  sets_input = (exerciseDetail as? ExerciseDetail.TimeBased)?.sets.toString()
+
+                  exerciseDetail =
+                    (exerciseDetail as? ExerciseDetail.TimeBased)
+                      ?: seletedExerciseTypeDetail.copy()
+                  //Duration
                   OutlinedTextField(
-                      value =
-                          (exerciseDetail as ExerciseDetail.TimeBased).durationInSeconds.toString(),
+                      value = if (durationInSeconds_input!= "0") durationInSeconds_input else "" ,
                       onValueChange = {
+                        durationInSeconds_input = it
                         val newValue = it.toIntOrNull()
-                        if (newValue != null) {
-                          exerciseDetail =
-                              (exerciseDetail as ExerciseDetail.TimeBased).copy(
-                                  durationInSeconds = newValue)
-                        }
+                        exerciseDetail =
+                          (exerciseDetail as ExerciseDetail.TimeBased).copy(
+                            durationInSeconds = newValue ?: 0
+                          )
+
                       },
                       label = { Text("Duration (seconds)") },
                       modifier = Modifier.testTag("durationTextField"))
+                  //nb of sets
                   OutlinedTextField(
-                      value = (exerciseDetail as ExerciseDetail.TimeBased).sets.toString(),
-                      onValueChange = {
-                        val newValue = it.toIntOrNull()
-                        if (newValue != null) {
-                          exerciseDetail =
-                              (exerciseDetail as ExerciseDetail.TimeBased).copy(sets = newValue)
-                        }
-                      },
+                      value = if (sets_input != "0") sets_input else "" ,
+                    onValueChange = {
+                      durationInSeconds_input = it
+                      val newValue = it.toIntOrNull()
+                      exerciseDetail =
+                        (exerciseDetail as ExerciseDetail.TimeBased).copy(
+                          sets = newValue ?: 0
+                        )
+                    },
                       label = { Text("Sets") },
                       modifier = Modifier.testTag("setsTextField"))
                 }
+
+
                 is ExerciseDetail.RepetitionBased -> {
+                  repetitions_input = (exerciseDetail as? ExerciseDetail.RepetitionBased)?.repetitions.toString()
+                  exerciseDetail =
+                    (exerciseDetail as? ExerciseDetail.RepetitionBased)
+                      ?: seletedExerciseTypeDetail.copy()
+
                   OutlinedTextField(
-                      value =
-                          (exerciseDetail as ExerciseDetail.RepetitionBased).repetitions.toString(),
+                      value = if (repetitions_input != "0") repetitions_input else "" ,
                       onValueChange = {
+                        durationInSeconds_input = it
                         val newValue = it.toIntOrNull()
-                        if (newValue != null) {
-                          exerciseDetail =
-                              (exerciseDetail as ExerciseDetail.RepetitionBased).copy(
-                                  repetitions = newValue)
-                        }
+                        exerciseDetail =
+                          (exerciseDetail as ExerciseDetail.RepetitionBased).copy(
+                            repetitions = newValue ?: 0
+                          )
                       },
                       label = { Text("Repetitions") },
                       modifier = Modifier.testTag("repetitionsTextField"))

--- a/app/src/main/java/com/android/sample/ui/workout/WorkoutCreationScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/workout/WorkoutCreationScreen.kt
@@ -103,7 +103,6 @@ fun WorkoutCreationScreen(
   var sets_input by remember { mutableStateOf("") }
   var repetitions_input by remember { mutableStateOf("") }
 
-
   Scaffold(
       topBar = {
         TopAppBar(
@@ -346,57 +345,52 @@ fun WorkoutCreationScreen(
 
               when (seletedExerciseTypeDetail) {
                 is ExerciseDetail.TimeBased -> {
-                  durationInSeconds_input = (exerciseDetail as? ExerciseDetail.TimeBased)?.durationInSeconds.toString()
+                  durationInSeconds_input =
+                      (exerciseDetail as? ExerciseDetail.TimeBased)?.durationInSeconds.toString()
                   sets_input = (exerciseDetail as? ExerciseDetail.TimeBased)?.sets.toString()
 
                   exerciseDetail =
-                    (exerciseDetail as? ExerciseDetail.TimeBased)
-                      ?: seletedExerciseTypeDetail.copy()
-                  //Duration
+                      (exerciseDetail as? ExerciseDetail.TimeBased)
+                          ?: seletedExerciseTypeDetail.copy()
+                  // Duration
                   OutlinedTextField(
-                      value = if (durationInSeconds_input!= "0") durationInSeconds_input else "" ,
+                      value = if (durationInSeconds_input != "0") durationInSeconds_input else "",
                       onValueChange = {
                         durationInSeconds_input = it
                         val newValue = it.toIntOrNull()
                         exerciseDetail =
-                          (exerciseDetail as ExerciseDetail.TimeBased).copy(
-                            durationInSeconds = newValue ?: 0
-                          )
-
+                            (exerciseDetail as ExerciseDetail.TimeBased).copy(
+                                durationInSeconds = newValue ?: 0)
                       },
                       label = { Text("Duration (seconds)") },
                       modifier = Modifier.testTag("durationTextField"))
-                  //nb of sets
+                  // nb of sets
                   OutlinedTextField(
-                      value = if (sets_input != "0") sets_input else "" ,
-                    onValueChange = {
-                      durationInSeconds_input = it
-                      val newValue = it.toIntOrNull()
-                      exerciseDetail =
-                        (exerciseDetail as ExerciseDetail.TimeBased).copy(
-                          sets = newValue ?: 0
-                        )
-                    },
-                      label = { Text("Sets") },
-                      modifier = Modifier.testTag("setsTextField"))
-                }
-
-
-                is ExerciseDetail.RepetitionBased -> {
-                  repetitions_input = (exerciseDetail as? ExerciseDetail.RepetitionBased)?.repetitions.toString()
-                  exerciseDetail =
-                    (exerciseDetail as? ExerciseDetail.RepetitionBased)
-                      ?: seletedExerciseTypeDetail.copy()
-
-                  OutlinedTextField(
-                      value = if (repetitions_input != "0") repetitions_input else "" ,
+                      value = if (sets_input != "0") sets_input else "",
                       onValueChange = {
                         durationInSeconds_input = it
                         val newValue = it.toIntOrNull()
                         exerciseDetail =
-                          (exerciseDetail as ExerciseDetail.RepetitionBased).copy(
-                            repetitions = newValue ?: 0
-                          )
+                            (exerciseDetail as ExerciseDetail.TimeBased).copy(sets = newValue ?: 0)
+                      },
+                      label = { Text("Sets") },
+                      modifier = Modifier.testTag("setsTextField"))
+                }
+                is ExerciseDetail.RepetitionBased -> {
+                  repetitions_input =
+                      (exerciseDetail as? ExerciseDetail.RepetitionBased)?.repetitions.toString()
+                  exerciseDetail =
+                      (exerciseDetail as? ExerciseDetail.RepetitionBased)
+                          ?: seletedExerciseTypeDetail.copy()
+
+                  OutlinedTextField(
+                      value = if (repetitions_input != "0") repetitions_input else "",
+                      onValueChange = {
+                        durationInSeconds_input = it
+                        val newValue = it.toIntOrNull()
+                        exerciseDetail =
+                            (exerciseDetail as ExerciseDetail.RepetitionBased).copy(
+                                repetitions = newValue ?: 0)
                       },
                       label = { Text("Repetitions") },
                       modifier = Modifier.testTag("repetitionsTextField"))

--- a/app/src/main/java/com/android/sample/ui/workout/WorkoutCreationScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/workout/WorkoutCreationScreen.kt
@@ -313,6 +313,7 @@ fun WorkoutCreationScreen(
                             DropdownMenuItem(
                                 onClick = {
                                   selectedExerciseType = type
+                                  exerciseDetail = type.detail
                                   isDropdownExpanded = false
                                 },
                                 modifier = Modifier.testTag("exerciseType${type.name}"),
@@ -326,6 +327,7 @@ fun WorkoutCreationScreen(
                             DropdownMenuItem(
                                 onClick = {
                                   selectedExerciseType = type
+                                  exerciseDetail = type.detail
                                   isDropdownExpanded = false
                                 },
                                 modifier = Modifier.testTag("exerciseType${type.name}"),
@@ -345,18 +347,18 @@ fun WorkoutCreationScreen(
 
               when (seletedExerciseTypeDetail) {
                 is ExerciseDetail.TimeBased -> {
-                  durationInSeconds_input =
-                      (exerciseDetail as? ExerciseDetail.TimeBased)?.durationInSeconds.toString()
-                  sets_input = (exerciseDetail as? ExerciseDetail.TimeBased)?.sets.toString()
-
-                  exerciseDetail =
-                      (exerciseDetail as? ExerciseDetail.TimeBased)
-                          ?: seletedExerciseTypeDetail.copy()
                   // Duration
                   OutlinedTextField(
-                      value = if (durationInSeconds_input != "0") durationInSeconds_input else "",
+                      value =
+                          if ((exerciseDetail as ExerciseDetail.TimeBased)
+                              .durationInSeconds
+                              .toString() == "0")
+                              ""
+                          else
+                              (exerciseDetail as ExerciseDetail.TimeBased)
+                                  .durationInSeconds
+                                  .toString(),
                       onValueChange = {
-                        durationInSeconds_input = it
                         val newValue = it.toIntOrNull()
                         exerciseDetail =
                             (exerciseDetail as ExerciseDetail.TimeBased).copy(
@@ -366,9 +368,11 @@ fun WorkoutCreationScreen(
                       modifier = Modifier.testTag("durationTextField"))
                   // nb of sets
                   OutlinedTextField(
-                      value = if (sets_input != "0") sets_input else "",
+                      value =
+                          if ((exerciseDetail as ExerciseDetail.TimeBased).sets.toString() == "0")
+                              ""
+                          else (exerciseDetail as ExerciseDetail.TimeBased).sets.toString(),
                       onValueChange = {
-                        durationInSeconds_input = it
                         val newValue = it.toIntOrNull()
                         exerciseDetail =
                             (exerciseDetail as ExerciseDetail.TimeBased).copy(sets = newValue ?: 0)
@@ -377,20 +381,19 @@ fun WorkoutCreationScreen(
                       modifier = Modifier.testTag("setsTextField"))
                 }
                 is ExerciseDetail.RepetitionBased -> {
-                  repetitions_input =
-                      (exerciseDetail as? ExerciseDetail.RepetitionBased)?.repetitions.toString()
-                  exerciseDetail =
-                      (exerciseDetail as? ExerciseDetail.RepetitionBased)
-                          ?: seletedExerciseTypeDetail.copy()
-
                   OutlinedTextField(
-                      value = if (repetitions_input != "0") repetitions_input else "",
+                      value =
+                          if ((exerciseDetail as ExerciseDetail.RepetitionBased)
+                              .repetitions
+                              .toString() == "0")
+                              ""
+                          else
+                              (exerciseDetail as ExerciseDetail.RepetitionBased)
+                                  .repetitions
+                                  .toString(),
                       onValueChange = {
-                        durationInSeconds_input = it
                         val newValue = it.toIntOrNull()
-                        exerciseDetail =
-                            (exerciseDetail as ExerciseDetail.RepetitionBased).copy(
-                                repetitions = newValue ?: 0)
+                        exerciseDetail = ExerciseDetail.RepetitionBased(repetitions = newValue ?: 0)
                       },
                       label = { Text("Repetitions") },
                       modifier = Modifier.testTag("repetitionsTextField"))

--- a/app/src/main/java/com/android/sample/ui/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/workout/WorkoutScreen.kt
@@ -123,7 +123,7 @@ fun WarmUpScreenBody(
           )
   // the goalCenterBox contains either the image of the exercise or the timer
   var goalCounterBoxIsDisplayed by remember { mutableStateOf(false) }
-  var countDownTimerIsPaused by remember { mutableStateOf(false) }
+  var countDownTimerIsPaused by remember { mutableStateOf(true) }
   var comparisonVideoIsDisplayed by remember { mutableStateOf(false) }
   // Setting a countdown or not before the time based exercises begins
   var isCountdownTime by remember {
@@ -180,6 +180,7 @@ fun WarmUpScreenBody(
   if (!exerciseIsRepetitionBased) {
     val rawDetail = exerciseState.exercise.detail as ExerciseDetail.TimeBased
     isCountdownTime = true
+    countDownTimerIsPaused = true
     timeLimit = rawDetail.durationInSeconds * rawDetail.sets
     timer = timeLimit
 
@@ -403,7 +404,7 @@ fun WarmUpScreenBody(
                                   else if (userHasRecorded) "Record again" else "Tap to record")
                             }
                       }
-
+                      Spacer(Modifier.size(25.dp))
                       SkipButton(onClick = { nextExercise() })
                       Spacer(Modifier.size(25.dp))
                       Button(


### PR DESCRIPTION
## Summary

This PR improves the workflow for creating workouts and addresses several bugs. 

**Key changes:**

* **Automatic Detail Assignment:**  Workout creation is improved by automatically assigning appropriate details (time-based or repetition-based) to exercises.  For example, plank exercises will default to time-based. This eliminates unnecessary user input and simplifies the process.
* **Default Values for Exercise Details:** To further assist users, default values are provided for exercise details. These defaults are tailored to beginner users, offering a starting point that can be easily customized. For example, the Tree Pose exercise defaults to two sets of 30 seconds.
* **Bug Fix - Exercise Goal Input:**  The issue with the exercise goal input field has been resolved. Previously, deleted characters would sometimes remain visible.
* **Automatic Timer Pause:** When starting an exercise, the countdown timer now automatically enters the PAUSE state. This allows users to prepare for the exercise without the timer running down.
* **Time-Based Exercise Formatting:** The formatting of time-based exercises has been improved. The previous format (`<min>X<Repetition>`) was not granular enough for exercises with durations less than one minute.

**Modified Files:**

* `WorkoutCreationTest.kt`: Tests adapted to reflect the removal of the manual time/repetition selection.
* `Exercise.kt`: Default values added for exercise type details.
* `WorkoutScreen.kt`:  Automatic timer pause implemented.
* `ExerciseCard.kt`: Time-based exercise formatting updated.
* `WorkoutCreationScreen.kt`: Automatic detail assignment for exercises implemented.