### PR TITLE
Fix/quick workout shared

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/workout/QuickWorkoutTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/workout/QuickWorkoutTest.kt
@@ -86,8 +86,8 @@ class QuickWorkoutTest {
     `when`(bodyWeightRepo.getDocuments(any(), any())).then {
       it.getArgument<(List<BodyWeightWorkout>) -> Unit>(0)(bodyWeightWorkouts)
     }
-      `when`(bodyWeightRepo.getNewUid()).thenReturn("mocked-bodyweight-uid")
-      `when`(yogaRepo.getNewUid()).thenReturn("mocked-yoga-uid")
+    `when`(bodyWeightRepo.getNewUid()).thenReturn("mocked-bodyweight-uid")
+    `when`(yogaRepo.getNewUid()).thenReturn("mocked-yoga-uid")
 
     `when`(yogaRepo.getDocuments(any(), any())).then {
       it.getArgument<(List<YogaWorkout>) -> Unit>(0)(yogaWorkouts)
@@ -122,19 +122,22 @@ class QuickWorkoutTest {
     val nodes = composeTestRule.onAllNodesWithTag("QuickWorkoutButton")
     val expectedWorkouts: List<Workout> =
         listOf(
-            BodyWeightWorkout.WARMUP_WORKOUT,
-            BodyWeightWorkout.WORKOUT_PUSH_UPS,
-            YogaWorkout.QUICK_YOGA_WORKOUT,
-            BodyWeightWorkout.QUICK_BODY_WEIGHT_WORKOUT).map {
-            when (it) {
-                is BodyWeightWorkout -> bodyWeightViewModel.copyOf(it) //In this test, the new UID is harcoded
+                BodyWeightWorkout.WARMUP_WORKOUT,
+                BodyWeightWorkout.WORKOUT_PUSH_UPS,
+                YogaWorkout.QUICK_YOGA_WORKOUT,
+                BodyWeightWorkout.QUICK_BODY_WEIGHT_WORKOUT)
+            .map {
+              when (it) {
+                is BodyWeightWorkout ->
+                    bodyWeightViewModel.copyOf(it) // In this test, the new UID is harcoded
                 is YogaWorkout -> yogaViewModel.copyOf(it)
-                else -> {null as Workout}
+                else -> {
+                  null as Workout
+                }
+              }
             }
-        }
 
-
-      for (i in 0 until nodes.fetchSemanticsNodes().size) {
+    for (i in 0 until nodes.fetchSemanticsNodes().size) {
       nodes[i].performClick()
       when (i) {
         0 -> assert(equals(bodyWeightViewModel.selectedWorkout.value!!, expectedWorkouts[i]))
@@ -145,14 +148,13 @@ class QuickWorkoutTest {
     }
   }
 
-    private fun equals(workout1: Workout, workout2: Workout): Boolean {
-        return workout1.workoutId == workout2.workoutId &&
-            workout1.name == workout2.name &&
-            workout1.description == workout2.description &&
-            workout1.warmup == workout2.warmup &&
-                workout1.date == workout2.date &&
-                workout1.userIdSet == workout2.userIdSet &&
-                workout1.exercises == workout2.exercises
-
-    }
+  private fun equals(workout1: Workout, workout2: Workout): Boolean {
+    return workout1.workoutId == workout2.workoutId &&
+        workout1.name == workout2.name &&
+        workout1.description == workout2.description &&
+        workout1.warmup == workout2.warmup &&
+        workout1.date == workout2.date &&
+        workout1.userIdSet == workout2.userIdSet &&
+        workout1.exercises == workout2.exercises
+  }
 }

--- a/app/src/androidTest/java/com/android/sample/ui/workout/QuickWorkoutTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/workout/QuickWorkoutTest.kt
@@ -10,6 +10,7 @@ import com.android.sample.model.userAccount.UserAccountRepository
 import com.android.sample.model.userAccount.UserAccountViewModel
 import com.android.sample.model.userAccount.WeightUnit
 import com.android.sample.model.workout.BodyWeightWorkout
+import com.android.sample.model.workout.Workout
 import com.android.sample.model.workout.WorkoutRepository
 import com.android.sample.model.workout.WorkoutViewModel
 import com.android.sample.model.workout.YogaWorkout
@@ -85,6 +86,8 @@ class QuickWorkoutTest {
     `when`(bodyWeightRepo.getDocuments(any(), any())).then {
       it.getArgument<(List<BodyWeightWorkout>) -> Unit>(0)(bodyWeightWorkouts)
     }
+      `when`(bodyWeightRepo.getNewUid()).thenReturn("mocked-bodyweight-uid")
+      `when`(yogaRepo.getNewUid()).thenReturn("mocked-yoga-uid")
 
     `when`(yogaRepo.getDocuments(any(), any())).then {
       it.getArgument<(List<YogaWorkout>) -> Unit>(0)(yogaWorkouts)
@@ -117,21 +120,39 @@ class QuickWorkoutTest {
   @Test
   fun testQuickWorkoutButtonsSelectCorrectWorkout() {
     val nodes = composeTestRule.onAllNodesWithTag("QuickWorkoutButton")
-    val expectedWorkouts =
+    val expectedWorkouts: List<Workout> =
         listOf(
             BodyWeightWorkout.WARMUP_WORKOUT,
             BodyWeightWorkout.WORKOUT_PUSH_UPS,
             YogaWorkout.QUICK_YOGA_WORKOUT,
-            BodyWeightWorkout.QUICK_BODY_WEIGHT_WORKOUT)
+            BodyWeightWorkout.QUICK_BODY_WEIGHT_WORKOUT).map {
+            when (it) {
+                is BodyWeightWorkout -> bodyWeightViewModel.copyOf(it) //In this test, the new UID is harcoded
+                is YogaWorkout -> yogaViewModel.copyOf(it)
+                else -> {null as Workout}
+            }
+        }
 
-    for (i in 0 until nodes.fetchSemanticsNodes().size) {
+
+      for (i in 0 until nodes.fetchSemanticsNodes().size) {
       nodes[i].performClick()
       when (i) {
-        0 -> assert(bodyWeightViewModel.selectedWorkout.value == expectedWorkouts[i])
-        1 -> assert(bodyWeightViewModel.selectedWorkout.value == expectedWorkouts[i])
-        2 -> assert(yogaViewModel.selectedWorkout.value == expectedWorkouts[i])
-        3 -> assert(bodyWeightViewModel.selectedWorkout.value == expectedWorkouts[i])
+        0 -> assert(equals(bodyWeightViewModel.selectedWorkout.value!!, expectedWorkouts[i]))
+        1 -> assert(equals(bodyWeightViewModel.selectedWorkout.value!!, expectedWorkouts[i]))
+        2 -> assert(equals(yogaViewModel.selectedWorkout.value!!, expectedWorkouts[i]))
+        3 -> assert(equals(bodyWeightViewModel.selectedWorkout.value!!, expectedWorkouts[i]))
       }
     }
   }
+
+    private fun equals(workout1: Workout, workout2: Workout): Boolean {
+        return workout1.workoutId == workout2.workoutId &&
+            workout1.name == workout2.name &&
+            workout1.description == workout2.description &&
+            workout1.warmup == workout2.warmup &&
+                workout1.date == workout2.date &&
+                workout1.userIdSet == workout2.userIdSet &&
+                workout1.exercises == workout2.exercises
+
+    }
 }

--- a/app/src/main/java/com/android/sample/model/workout/Workout.kt
+++ b/app/src/main/java/com/android/sample/model/workout/Workout.kt
@@ -71,4 +71,5 @@ enum class WorkoutType {
       WARMUP -> "Warm-up"
     }
   }
+
 }

--- a/app/src/main/java/com/android/sample/model/workout/Workout.kt
+++ b/app/src/main/java/com/android/sample/model/workout/Workout.kt
@@ -71,5 +71,4 @@ enum class WorkoutType {
       WARMUP -> "Warm-up"
     }
   }
-
 }

--- a/app/src/main/java/com/android/sample/model/workout/WorkoutViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/workout/WorkoutViewModel.kt
@@ -65,4 +65,32 @@ open class WorkoutViewModel<out T : Workout>(private val repository: WorkoutRepo
   fun selectWorkout(workout: @UnsafeVariance T) {
     selectedWorkout_.value = workout
   }
+
+  /**
+   * Copies a workout object and returns a new instance with all the same properties except for the ID, which is a newly generated unique identifier.
+   * @param workout The workout object to be copied. Must be a subclass of [Workout].
+   */
+  fun <T : Workout> copyOf(workout: T): T {
+    return when (workout) {
+      is BodyWeightWorkout -> BodyWeightWorkout(
+        getNewUid(),
+        workout.name,
+        workout.description,
+        workout.warmup,
+        workout.userIdSet,
+        workout.exercises,
+        workout.date
+      ) as T
+      is YogaWorkout -> YogaWorkout(
+        getNewUid(),
+        workout.name,
+        workout.description,
+        workout.warmup,
+        workout.userIdSet,
+        workout.exercises,
+        workout.date
+      ) as T
+      else -> TODO()
+    }
+  }
 }

--- a/app/src/main/java/com/android/sample/model/workout/WorkoutViewModel.kt
+++ b/app/src/main/java/com/android/sample/model/workout/WorkoutViewModel.kt
@@ -67,29 +67,33 @@ open class WorkoutViewModel<out T : Workout>(private val repository: WorkoutRepo
   }
 
   /**
-   * Copies a workout object and returns a new instance with all the same properties except for the ID, which is a newly generated unique identifier.
+   * Copies a workout object and returns a new instance with all the same properties except for the
+   * ID, which is a newly generated unique identifier.
+   *
    * @param workout The workout object to be copied. Must be a subclass of [Workout].
    */
   fun <T : Workout> copyOf(workout: T): T {
     return when (workout) {
-      is BodyWeightWorkout -> BodyWeightWorkout(
-        getNewUid(),
-        workout.name,
-        workout.description,
-        workout.warmup,
-        workout.userIdSet,
-        workout.exercises,
-        workout.date
-      ) as T
-      is YogaWorkout -> YogaWorkout(
-        getNewUid(),
-        workout.name,
-        workout.description,
-        workout.warmup,
-        workout.userIdSet,
-        workout.exercises,
-        workout.date
-      ) as T
+      is BodyWeightWorkout ->
+          BodyWeightWorkout(
+              getNewUid(),
+              workout.name,
+              workout.description,
+              workout.warmup,
+              workout.userIdSet,
+              workout.exercises,
+              workout.date)
+              as T
+      is YogaWorkout ->
+          YogaWorkout(
+              getNewUid(),
+              workout.name,
+              workout.description,
+              workout.warmup,
+              workout.userIdSet,
+              workout.exercises,
+              workout.date)
+              as T
       else -> TODO()
     }
   }

--- a/app/src/main/java/com/android/sample/ui/mainscreen/MainScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/mainscreen/MainScreen.kt
@@ -292,19 +292,23 @@ fun QuickWorkoutButton(
               .clickable {
                 when (iconId) {
                   R.drawable.running_man -> {
-                    bodyWeightViewModel.selectWorkout(bodyWeightViewModel.copyOf(BodyWeightWorkout.WARMUP_WORKOUT))
+                    bodyWeightViewModel.selectWorkout(
+                        bodyWeightViewModel.copyOf(BodyWeightWorkout.WARMUP_WORKOUT))
                     navigationActions.navigateTo(Screen.BODY_WEIGHT_OVERVIEW)
                   }
                   R.drawable.pushups -> {
-                    bodyWeightViewModel.selectWorkout(bodyWeightViewModel.copyOf(BodyWeightWorkout.WORKOUT_PUSH_UPS))
+                    bodyWeightViewModel.selectWorkout(
+                        bodyWeightViewModel.copyOf(BodyWeightWorkout.WORKOUT_PUSH_UPS))
                     navigationActions.navigateTo(Screen.BODY_WEIGHT_OVERVIEW)
                   }
                   R.drawable.yoga -> {
-                    yogaViewModel.selectWorkout(yogaViewModel.copyOf(YogaWorkout.QUICK_YOGA_WORKOUT))
+                    yogaViewModel.selectWorkout(
+                        yogaViewModel.copyOf(YogaWorkout.QUICK_YOGA_WORKOUT))
                     navigationActions.navigateTo(Screen.YOGA_OVERVIEW)
                   }
                   R.drawable.dumbbell -> {
-                    bodyWeightViewModel.selectWorkout(bodyWeightViewModel.copyOf(BodyWeightWorkout.QUICK_BODY_WEIGHT_WORKOUT))
+                    bodyWeightViewModel.selectWorkout(
+                        bodyWeightViewModel.copyOf(BodyWeightWorkout.QUICK_BODY_WEIGHT_WORKOUT))
                     navigationActions.navigateTo(Screen.BODY_WEIGHT_OVERVIEW)
                   }
                 }

--- a/app/src/main/java/com/android/sample/ui/mainscreen/MainScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/mainscreen/MainScreen.kt
@@ -292,19 +292,19 @@ fun QuickWorkoutButton(
               .clickable {
                 when (iconId) {
                   R.drawable.running_man -> {
-                    bodyWeightViewModel.selectWorkout(BodyWeightWorkout.WARMUP_WORKOUT)
+                    bodyWeightViewModel.selectWorkout(bodyWeightViewModel.copyOf(BodyWeightWorkout.WARMUP_WORKOUT))
                     navigationActions.navigateTo(Screen.BODY_WEIGHT_OVERVIEW)
                   }
                   R.drawable.pushups -> {
-                    bodyWeightViewModel.selectWorkout(BodyWeightWorkout.WORKOUT_PUSH_UPS)
+                    bodyWeightViewModel.selectWorkout(bodyWeightViewModel.copyOf(BodyWeightWorkout.WORKOUT_PUSH_UPS))
                     navigationActions.navigateTo(Screen.BODY_WEIGHT_OVERVIEW)
                   }
                   R.drawable.yoga -> {
-                    yogaViewModel.selectWorkout(YogaWorkout.QUICK_YOGA_WORKOUT)
+                    yogaViewModel.selectWorkout(yogaViewModel.copyOf(YogaWorkout.QUICK_YOGA_WORKOUT))
                     navigationActions.navigateTo(Screen.YOGA_OVERVIEW)
                   }
                   R.drawable.dumbbell -> {
-                    bodyWeightViewModel.selectWorkout(BodyWeightWorkout.QUICK_BODY_WEIGHT_WORKOUT)
+                    bodyWeightViewModel.selectWorkout(bodyWeightViewModel.copyOf(BodyWeightWorkout.QUICK_BODY_WEIGHT_WORKOUT))
                     navigationActions.navigateTo(Screen.BODY_WEIGHT_OVERVIEW)
                   }
                 }


### PR DESCRIPTION
# Fix
The bug #127 is now fixed, quick workout are no more shared between users

# How
When pressing the Quick Workout button, it now creates a copy of the template using the new function "copyOf(workout)"

## copyOf() function
New function introduced in **WorkoutViewModel.kt**, that takes a workout and create a new one with copied values for each parameter, except for the UID, which should be unique and thus is generated using the getNewUid() method of WorkoutViewModel

## Conclusion
Since it's a new UID, the workouts are now differents from the point of view of Firebase, and a user changing a  quick workout on the go won't affect the template for all the others users