### PR TITLE
Fix/ Confirmation Before Deletion and TopBar for Edit Account

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/settings/DeleteConfirmationDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/settings/DeleteConfirmationDialogTest.kt
@@ -17,10 +17,8 @@ class DeleteConfirmationDialogTest {
 
   @Test
   fun dialogDisplaysCorrectText() {
-    // Arrange: Set up the dialog
     composeTestRule.setContent { DeleteConfirmationDialog(onConfirm = {}, onDismiss = {}) }
 
-    // Assert: Check that the title and message are displayed
     composeTestRule
         .onNodeWithText(context.getString(R.string.ConfirmDeleteTitle))
         .assertIsDisplayed()
@@ -33,15 +31,12 @@ class DeleteConfirmationDialogTest {
   fun confirmButtonTriggersAction() {
     var confirmClicked = false
 
-    // Arrange: Set up the dialog
     composeTestRule.setContent {
       DeleteConfirmationDialog(onConfirm = { confirmClicked = true }, onDismiss = {})
     }
 
-    // Act: Click the confirm button
     composeTestRule.onNodeWithText(context.getString(R.string.Confirm)).performClick()
 
-    // Assert: Confirm button action is triggered
     assert(confirmClicked)
   }
 
@@ -49,15 +44,12 @@ class DeleteConfirmationDialogTest {
   fun dismissButtonTriggersAction() {
     var dismissClicked = false
 
-    // Arrange: Set up the dialog
     composeTestRule.setContent {
       DeleteConfirmationDialog(onConfirm = {}, onDismiss = { dismissClicked = true })
     }
 
-    // Act: Click the dismiss button
     composeTestRule.onNodeWithText(context.getString(R.string.Cancel)).performClick()
 
-    // Assert: Dismiss button action is triggered
     assert(dismissClicked)
   }
 }

--- a/app/src/androidTest/java/com/android/sample/ui/settings/DeleteConfirmationDialogTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/settings/DeleteConfirmationDialogTest.kt
@@ -1,0 +1,63 @@
+package com.android.sample.ui.settings
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.android.sample.R
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DeleteConfirmationDialogTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+  private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+  @Test
+  fun dialogDisplaysCorrectText() {
+    // Arrange: Set up the dialog
+    composeTestRule.setContent { DeleteConfirmationDialog(onConfirm = {}, onDismiss = {}) }
+
+    // Assert: Check that the title and message are displayed
+    composeTestRule
+        .onNodeWithText(context.getString(R.string.ConfirmDeleteTitle))
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText(context.getString(R.string.ConfirmDeleteMessage))
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun confirmButtonTriggersAction() {
+    var confirmClicked = false
+
+    // Arrange: Set up the dialog
+    composeTestRule.setContent {
+      DeleteConfirmationDialog(onConfirm = { confirmClicked = true }, onDismiss = {})
+    }
+
+    // Act: Click the confirm button
+    composeTestRule.onNodeWithText(context.getString(R.string.Confirm)).performClick()
+
+    // Assert: Confirm button action is triggered
+    assert(confirmClicked)
+  }
+
+  @Test
+  fun dismissButtonTriggersAction() {
+    var dismissClicked = false
+
+    // Arrange: Set up the dialog
+    composeTestRule.setContent {
+      DeleteConfirmationDialog(onConfirm = {}, onDismiss = { dismissClicked = true })
+    }
+
+    // Act: Click the dismiss button
+    composeTestRule.onNodeWithText(context.getString(R.string.Cancel)).performClick()
+
+    // Assert: Dismiss button action is triggered
+    assert(dismissClicked)
+  }
+}

--- a/app/src/main/java/com/android/sample/ui/authentication/AddAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/AddAccount.kt
@@ -117,7 +117,7 @@ fun AddAccount(
   Column {
     // Add the TopBar only when editing an account
     if (accountExists) {
-      TopBar(navigationActions = navigationActions, title = R.string.edit_account_title)
+      TopBar(navigationActions = navigationActions, title = R.string.EditAccount)
     }
     AccountForm(
         profileImageUri = profileImageUri,

--- a/app/src/main/java/com/android/sample/ui/authentication/AddAccount.kt
+++ b/app/src/main/java/com/android/sample/ui/authentication/AddAccount.kt
@@ -24,8 +24,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
+import com.android.sample.R
 import com.android.sample.model.userAccount.*
 import com.android.sample.model.userAccount.UserAccountViewModel
+import com.android.sample.ui.composables.TopBar
 import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.TopLevelDestinations
 import com.google.firebase.Firebase
@@ -81,8 +83,11 @@ fun AddAccount(
             it.birthDate.let { timestamp ->
               val calendar = Calendar.getInstance()
               calendar.time = timestamp.toDate()
-              "${calendar.get(Calendar.DAY_OF_MONTH)}/${calendar.get(Calendar.MONTH) + 1}/${calendar.get(
-                            Calendar.YEAR)}"
+              "${calendar.get(Calendar.DAY_OF_MONTH)}/${calendar.get(Calendar.MONTH) + 1}/${
+                            calendar.get(
+                                Calendar.YEAR
+                            )
+                        }"
             }
         // Check for valid URI before assigning it
         try {
@@ -109,49 +114,55 @@ fun AddAccount(
           contract = ActivityResultContracts.GetContent(),
           onResult = { uri -> profileImageUri = uri })
 
-  AccountForm(
-      profileImageUri = profileImageUri,
-      onImageClick = { imagePickerLauncher.launch("image/*") },
-      firstName = firstName,
-      lastName = lastName,
-      onFirstNameChange = { firstName = it },
-      onLastNameChange = { lastName = it },
-      height = height,
-      weight = weight,
-      heightUnit = heightUnit,
-      weightUnit = weightUnit,
-      onHeightChange = { height = it },
-      onWeightChange = { weight = it },
-      onHeightUnitChange = { heightUnit = it },
-      onWeightUnitChange = { weightUnit = it },
-      gender = gender,
-      onGenderChange = { gender = it },
-      birthDate = birthDate,
-      onBirthDateChange = { birthDate = it },
-      buttonText = if (accountExists) "Save Changes" else "Submit",
-      onButtonClick = {
-        saveAccount(
-            isNewAccount = !accountExists,
-            userAccountViewModel = userAccountViewModel,
-            navigationActions = navigationActions,
-            userId = if (accountExists) userId2 else actualUserId,
-            firstName = firstName,
-            lastName = lastName,
-            height = height,
-            heightUnit = heightUnit,
-            weight = weight,
-            weightUnit = weightUnit,
-            gender = gender,
-            birthDate = birthDate,
-            profileImageUri = profileImageUri,
-            originalProfileImageUri = if (accountExists) originalProfileImageUri else null,
-            friends = friends,
-            sentRequests = sentRequests,
-            receivedRequests = receivedRequests,
-            context = context)
-      },
-      isButtonEnabled = firstName.isNotBlank(),
-      testTag = if (accountExists) "editScreen" else "addScreen")
+  Column {
+    // Add the TopBar only when editing an account
+    if (accountExists) {
+      TopBar(navigationActions = navigationActions, title = R.string.edit_account_title)
+    }
+    AccountForm(
+        profileImageUri = profileImageUri,
+        onImageClick = { imagePickerLauncher.launch("image/*") },
+        firstName = firstName,
+        lastName = lastName,
+        onFirstNameChange = { firstName = it },
+        onLastNameChange = { lastName = it },
+        height = height,
+        weight = weight,
+        heightUnit = heightUnit,
+        weightUnit = weightUnit,
+        onHeightChange = { height = it },
+        onWeightChange = { weight = it },
+        onHeightUnitChange = { heightUnit = it },
+        onWeightUnitChange = { weightUnit = it },
+        gender = gender,
+        onGenderChange = { gender = it },
+        birthDate = birthDate,
+        onBirthDateChange = { birthDate = it },
+        buttonText = if (accountExists) "Save Changes" else "Submit",
+        onButtonClick = {
+          saveAccount(
+              isNewAccount = !accountExists,
+              userAccountViewModel = userAccountViewModel,
+              navigationActions = navigationActions,
+              userId = if (accountExists) userId2 else actualUserId,
+              firstName = firstName,
+              lastName = lastName,
+              height = height,
+              heightUnit = heightUnit,
+              weight = weight,
+              weightUnit = weightUnit,
+              gender = gender,
+              birthDate = birthDate,
+              profileImageUri = profileImageUri,
+              originalProfileImageUri = if (accountExists) originalProfileImageUri else null,
+              friends = friends,
+              sentRequests = sentRequests,
+              receivedRequests = receivedRequests,
+              context = context)
+        },
+        isButtonEnabled = firstName.isNotBlank(),
+        testTag = if (accountExists) "editScreen" else "addScreen")
+  }
 }
 
 @Composable

--- a/app/src/main/java/com/android/sample/ui/settings/DeleteConfirmationDialog.kt
+++ b/app/src/main/java/com/android/sample/ui/settings/DeleteConfirmationDialog.kt
@@ -1,0 +1,22 @@
+package com.android.sample.ui.settings
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.android.sample.R
+
+@Composable
+fun DeleteConfirmationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
+  AlertDialog(
+      onDismissRequest = { onDismiss() },
+      title = { Text(stringResource(id = R.string.ConfirmDeleteTitle)) },
+      text = { Text(stringResource(id = R.string.ConfirmDeleteMessage)) },
+      confirmButton = {
+        TextButton(onClick = { onConfirm() }) { Text(stringResource(id = R.string.Confirm)) }
+      },
+      dismissButton = {
+        TextButton(onClick = { onDismiss() }) { Text(stringResource(id = R.string.Cancel)) }
+      })
+}

--- a/app/src/main/java/com/android/sample/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/settings/SettingsScreen.kt
@@ -12,6 +12,10 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.ExitToApp
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -39,6 +43,7 @@ fun SettingsScreen(
     userAccountViewModel: UserAccountViewModel = viewModel(factory = UserAccountViewModel.Factory)
 ) {
   val context = LocalContext.current
+  var showDeleteConfirmation by remember { mutableStateOf(false) }
 
   Scaffold(
       modifier = Modifier.testTag("settingsScreen"),
@@ -67,25 +72,7 @@ fun SettingsScreen(
                   verticalArrangement = Arrangement.Bottom,
                   horizontalAlignment = Alignment.CenterHorizontally) {
                     RedButton(
-                        onClick = {
-                          userAccountViewModel.deleteAccount(
-                              context,
-                              onSuccess = {
-                                Toast.makeText(
-                                        context,
-                                        R.string.SuccesfulDeleteMessage,
-                                        Toast.LENGTH_SHORT)
-                                    .show()
-                                navigationActions.navigateTo("Auth Screen")
-                              },
-                              onFailure = { error ->
-                                Toast.makeText(
-                                        context,
-                                        "Failed to delete account: ${error.message}",
-                                        Toast.LENGTH_LONG)
-                                    .show()
-                              })
-                        },
+                        onClick = { showDeleteConfirmation = true }, // Show the confirmation dialog
                         image = Icons.Outlined.Delete,
                         title = R.string.Delete_Account,
                         modifier = Modifier.fillMaxWidth().testTag("deleteAccountButton"))
@@ -104,6 +91,26 @@ fun SettingsScreen(
                   }
             }
       })
+
+  // Separate composable for the confirmation dialog
+  if (showDeleteConfirmation) {
+    DeleteConfirmationDialog(
+        onConfirm = {
+          userAccountViewModel.deleteAccount(
+              context,
+              onSuccess = {
+                Toast.makeText(context, R.string.SuccesfulDeleteMessage, Toast.LENGTH_SHORT).show()
+                navigationActions.navigateTo("Auth Screen")
+              },
+              onFailure = { error ->
+                Toast.makeText(
+                        context, "Failed to delete account: ${error.message}", Toast.LENGTH_LONG)
+                    .show()
+              })
+          showDeleteConfirmation = false
+        },
+        onDismiss = { showDeleteConfirmation = false })
+  }
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,5 +37,5 @@
     <string name="ConfirmDeleteMessage">Are you sure you want to delete your account? This action cannot be undone.</string>
     <string name="Confirm">Confirm</string>
     <string name="Cancel">Cancel</string>
-    <string name="edit_account_title">Edit Account</string>
+    <string name="EditAccount">Edit Account</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,9 @@
     <string name="YogaWorkoutTitle">Yoga</string>
     <string name="new_session">New Session</string>
     <string name="SkippedTextCard">Skipped</string>
+    <string name="ConfirmDeleteTitle">Delete Account</string>
+    <string name="ConfirmDeleteMessage">Are you sure you want to delete your account? This action cannot be undone.</string>
+    <string name="Confirm">Confirm</string>
+    <string name="Cancel">Cancel</string>
+    <string name="edit_account_title">Edit Account</string>
 </resources>


### PR DESCRIPTION
### **Modified Files:**

- DeleteConfirmationDialog.kt
- SettingsScreen.kt
- AddAccount.kt

### **Summary:**

This pull request improves user experience by introducing two key changes to the application:

**1. Delete Confirmation Dialog:**
- Added a dedicated confirmation dialog for the account deletion feature to prevent accidental deletions.
- The dialog requires users to explicitly confirm or cancel their deletion request.
- Updated SettingsScreen.kt to display this dialog when the user clicks the “Delete Account” button.

**2. TopBar for Edit Account:**
- Introduced a TopBar to the Edit Account screen for better navigation and visual consistency.
- The TopBar is conditionally displayed only when the user is editing an account and includes a title and back navigation.

### **Details:**

**1. DeleteConfirmationDialog.kt:**
- Created a reusable composable to handle the confirmation dialog with customizable confirm and dismiss actions.
- Integrated the dialog into SettingsScreen.kt using a state variable to control visibility.

**2. SettingsScreen.kt:**
- Updated the “Delete Account” button logic to trigger the confirmation dialog instead of directly deleting the account.

**3. strings.xml:**
	•	Added string resources for the delete confirmation dialog title, message, and button labels (Confirm, Cancel).
	•	Added a title for the Edit Account screen.