### PR TITLE
Add Architecture Diagram link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ running companion as well as consulting his/her progression offline
 
 # Figma 
 We have a Figma project for the app design and navigation. Here is the [link](https://www.figma.com/design/rZgylXKE9PmQgKigHpzMtr/Sport-Companion?node-id=0-1&m=dev&t=RZbHJEZFt2Uhlm2P-1) to the project.
+
+# Architecture Diagram
+Here is the link to the architecture diagram of the app. [link](https://github.com/EndurAi/EndurAi/wiki/Architecture-Diagram)


### PR DESCRIPTION
This Pr adds the architecture diagram link to the readme as requested in the documentation.