### PR TITLE
New Google Maps API Key

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,7 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
     }
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
         </activity>
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyAYJzihUiV73nTkRL76TeXMqxJ4grIHxN4" />
+            android:value="${MAPS_API_KEY}" />
 
     </application>
 


### PR DESCRIPTION
This very little PR introduces a new Google Maps API Key.

Actually, the old key was published on github, which is very bad. That's why I completely destroy it and create a new one in the localProperties files in the github secret.