### PR TITLE
Clear the cache everytime the workouts are updated

### DIFF
--- a/app/src/main/java/com/android/sample/model/workout/WorkoutRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/workout/WorkoutRepositoryFirestore.kt
@@ -134,8 +134,11 @@ open class WorkoutRepositoryFirestore<T : Workout>(
         .set(dataMapWorkout)
         .addOnFailureListener { e -> onFailure(e) }
         .addOnSuccessListener {
-          onSuccess()
-          saveWorkoutsToCache(listOf(obj)) // Save to cache
+            CoroutineScope(Dispatchers.IO).launch {
+                localCache.clearWorkouts() // Save to cache
+                onSuccess()
+            }
+
         }
   }
 
@@ -224,8 +227,10 @@ open class WorkoutRepositoryFirestore<T : Workout>(
         .document(obj.workoutId)
         .set(dataMap)
         .addOnSuccessListener {
-          onSuccess()
-          updateWorkoutInCache(obj) // Update in cache
+            CoroutineScope(Dispatchers.IO).launch {
+                localCache.clearWorkouts()// Update in cache
+                onSuccess()
+            }
         }
         .addOnFailureListener { e -> onFailure(e) }
   }
@@ -255,8 +260,10 @@ open class WorkoutRepositoryFirestore<T : Workout>(
         .delete()
         .addOnFailureListener { e -> onFailure(e) }
         .addOnSuccessListener {
-          onSuccess()
-          removeWorkoutFromCache(id) // Remove from cache
+            CoroutineScope(Dispatchers.IO).launch {
+                localCache.clearWorkouts() // Remove from cache
+                onSuccess()
+            }
         }
   }
 

--- a/app/src/main/java/com/android/sample/model/workout/WorkoutRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/sample/model/workout/WorkoutRepositoryFirestore.kt
@@ -134,11 +134,10 @@ open class WorkoutRepositoryFirestore<T : Workout>(
         .set(dataMapWorkout)
         .addOnFailureListener { e -> onFailure(e) }
         .addOnSuccessListener {
-            CoroutineScope(Dispatchers.IO).launch {
-                localCache.clearWorkouts() // Save to cache
-                onSuccess()
-            }
-
+          CoroutineScope(Dispatchers.IO).launch {
+            localCache.clearWorkouts() // Save to cache
+            onSuccess()
+          }
         }
   }
 
@@ -227,10 +226,10 @@ open class WorkoutRepositoryFirestore<T : Workout>(
         .document(obj.workoutId)
         .set(dataMap)
         .addOnSuccessListener {
-            CoroutineScope(Dispatchers.IO).launch {
-                localCache.clearWorkouts()// Update in cache
-                onSuccess()
-            }
+          CoroutineScope(Dispatchers.IO).launch {
+            localCache.clearWorkouts() // Update in cache
+            onSuccess()
+          }
         }
         .addOnFailureListener { e -> onFailure(e) }
   }
@@ -260,10 +259,10 @@ open class WorkoutRepositoryFirestore<T : Workout>(
         .delete()
         .addOnFailureListener { e -> onFailure(e) }
         .addOnSuccessListener {
-            CoroutineScope(Dispatchers.IO).launch {
-                localCache.clearWorkouts() // Remove from cache
-                onSuccess()
-            }
+          CoroutineScope(Dispatchers.IO).launch {
+            localCache.clearWorkouts() // Remove from cache
+            onSuccess()
+          }
         }
   }
 


### PR DESCRIPTION
## Summary
It seems like there is a race condition with the cache which makes it sometimes not be up to date. So it is not good but I clear the cached workouts everytime we update the workout list. 